### PR TITLE
feat: AI Security layer for local AI coding agents

### DIFF
--- a/docs/neuralguard-policy.example.yaml
+++ b/docs/neuralguard-policy.example.yaml
@@ -1,0 +1,30 @@
+# NeuralGuard policy file — drop into ~/.config/synthia/security/policy.yaml
+#
+# Phase 1 keys honoured by src/synthia/hooks/security_gate.py:
+#
+#   default      : "allow" | "deny"   (currently informational)
+#   mode         : "permissive"  -> only block_on severities deny
+#                  "strict"      -> medium and above deny
+#                  "prompt"      -> ask via the GUI modal for any hit
+#   block_on     : list of severities that always deny (default: [critical])
+#   llm_classifier:
+#     enabled    : false (off by default)
+#     model      : "claude-haiku-4-5-20251001"
+#     threshold  : minimum static-rule severity that triggers a second-pass
+#                  LLM intent check (default: medium)
+#
+# When the LLM classifier is on, its verdict OVERRIDES the static
+# severity in the recorded event. This catches both novel jailbreaks
+# (rules clean -> still escalate via classifier upgrade) AND noisy
+# false positives (rule says critical, classifier sees benign intent
+# and downgrades to info, letting the call through).
+
+default: allow
+mode: permissive
+block_on:
+  - critical
+
+llm_classifier:
+  enabled: false
+  model: claude-haiku-4-5-20251001
+  threshold: medium

--- a/gui/src-tauri/src/egress.rs
+++ b/gui/src-tauri/src/egress.rs
@@ -1,0 +1,212 @@
+//! Egress monitor for AI agents.
+//!
+//! Polls `ss` periodically, finds established TCP connections owned by any
+//! running claude/opencode/kimi/codex process, and flags destinations not
+//! on the allowlist. Off by default — flip `egress_enabled` in
+//! ~/.config/synthia/runtime.json (or via the GUI toggle) to turn it on.
+
+use std::collections::HashSet;
+use std::net::ToSocketAddrs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use crate::security;
+
+const DEFAULT_ALLOWLIST: &[&str] = &[
+    "api.anthropic.com",
+    "claude.ai",
+    "console.anthropic.com",
+    "api.openai.com",
+    "api.x.ai",
+    "api.deepseek.com",
+    "api.moonshot.cn",
+    "api.moonshot.ai",
+    "github.com",
+    "api.github.com",
+    "raw.githubusercontent.com",
+    "objects.githubusercontent.com",
+    "codeload.github.com",
+    "registry.npmjs.org",
+    "pypi.org",
+    "files.pythonhosted.org",
+    "deb.debian.org",
+    "archive.ubuntu.com",
+    "security.ubuntu.com",
+    "dl.google.com",
+    "huggingface.co",
+    "cdn-lfs.huggingface.co",
+];
+
+const POLL_INTERVAL_S: u64 = 30;
+const RESOLVE_TTL_S: u64 = 600;
+
+static REPORTED: Mutex<Option<HashSet<String>>> = Mutex::new(None);
+
+pub fn runtime_state_path() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    PathBuf::from(home).join(".config/synthia/runtime.json")
+}
+
+pub fn is_enabled() -> bool {
+    let path = runtime_state_path();
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    serde_json::from_str::<serde_json::Value>(&content)
+        .ok()
+        .and_then(|v| v.get("egress_enabled").and_then(|b| b.as_bool()))
+        .unwrap_or(false)
+}
+
+fn resolve_allowlist() -> HashSet<String> {
+    let mut out = HashSet::new();
+    for host in DEFAULT_ALLOWLIST {
+        let target = format!("{}:443", host);
+        if let Ok(iter) = target.to_socket_addrs() {
+            for addr in iter {
+                out.insert(addr.ip().to_string());
+            }
+        }
+    }
+    out
+}
+
+fn list_ai_pids(self_pid: u32) -> HashSet<u32> {
+    crate::list_ai_processes(self_pid)
+        .into_iter()
+        .map(|(pid, _, _, _)| pid)
+        .collect()
+}
+
+fn read_proc_cwd(pid: u32) -> Option<String> {
+    std::fs::read_link(format!("/proc/{}/cwd", pid))
+        .ok()
+        .and_then(|p| p.to_str().map(|s| s.to_string()))
+}
+
+#[derive(Debug)]
+struct Connection {
+    pid: u32,
+    process: String,
+    peer_ip: String,
+    peer_port: u16,
+}
+
+fn poll_connections() -> Vec<Connection> {
+    let out = match Command::new("ss")
+        .args(["-Hntp", "state", "established"])
+        .output()
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return Vec::new(),
+    };
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let mut rows = Vec::new();
+    let pid_re = regex::Regex::new(r#"pid=(\d+)"#).ok();
+    let proc_re = regex::Regex::new(r#"\(\("([^"]+)""#).ok();
+    for line in stdout.lines() {
+        let toks: Vec<&str> = line.split_whitespace().collect();
+        if toks.len() < 5 {
+            continue;
+        }
+        let peer = toks[3];
+        let users = toks[4];
+        let (peer_ip, peer_port) = match peer.rsplit_once(':') {
+            Some((ip, port)) => (ip.trim_start_matches('[').trim_end_matches(']').to_string(),
+                                 port.parse::<u16>().unwrap_or(0)),
+            None => continue,
+        };
+        let pid = pid_re.as_ref()
+            .and_then(|r| r.captures(users))
+            .and_then(|c| c.get(1))
+            .and_then(|m| m.as_str().parse::<u32>().ok());
+        let process = proc_re.as_ref()
+            .and_then(|r| r.captures(users))
+            .and_then(|c| c.get(1))
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_default();
+        if let Some(pid) = pid {
+            rows.push(Connection { pid, process, peer_ip, peer_port });
+        }
+    }
+    rows
+}
+
+fn poll_once(allowlist: &HashSet<String>, ai_pids: &HashSet<u32>) {
+    let mut reported = match REPORTED.lock() {
+        Ok(g) => g,
+        Err(_) => return,
+    };
+    let set = reported.get_or_insert_with(HashSet::new);
+    for c in poll_connections() {
+        if !ai_pids.contains(&c.pid) {
+            continue;
+        }
+        if allowlist.contains(&c.peer_ip) {
+            continue;
+        }
+        // skip local + private
+        if c.peer_ip.starts_with("127.")
+            || c.peer_ip.starts_with("10.")
+            || c.peer_ip.starts_with("192.168.")
+            || c.peer_ip.starts_with("169.254.")
+            || c.peer_ip == "::1"
+        {
+            continue;
+        }
+        let key = format!("{}:{}:{}", c.pid, c.peer_ip, c.peer_port);
+        if !set.insert(key.clone()) {
+            continue;
+        }
+        let cwd = read_proc_cwd(c.pid);
+        let hit = security::RuleHit {
+            rule: "egress-unknown-host",
+            severity: security::Severity::Medium,
+            matched: format!("{}:{} (proc {})", c.peer_ip, c.peer_port, c.process),
+        };
+        let raw = serde_json::json!({
+            "pid": c.pid,
+            "process": c.process,
+            "peer_ip": c.peer_ip,
+            "peer_port": c.peer_port,
+        });
+        let event = security::make_event(
+            hit,
+            "Network",
+            raw,
+            Some(c.pid),
+            Some("claude"),
+            cwd.as_deref(),
+            None,
+            "observed",
+            "egress-monitor",
+        );
+        let _ = security::append_events(&[event]);
+    }
+}
+
+pub fn spawn_watcher() {
+    std::thread::spawn(|| {
+        let mut allowlist = resolve_allowlist();
+        let mut allowlist_ts = Instant::now();
+        loop {
+            std::thread::sleep(Duration::from_secs(POLL_INTERVAL_S));
+            if !is_enabled() {
+                continue;
+            }
+            if allowlist_ts.elapsed().as_secs() > RESOLVE_TTL_S {
+                allowlist = resolve_allowlist();
+                allowlist_ts = Instant::now();
+            }
+            let self_pid = std::process::id();
+            let pids = list_ai_pids(self_pid);
+            if pids.is_empty() {
+                continue;
+            }
+            poll_once(&allowlist, &pids);
+        }
+    });
+}

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -2150,6 +2150,8 @@ struct AgentInfo {
     role: String,        // "Developer" | "Technical Writer" | "Architect" | ...
     role_icon: String,   // emoji for the role
     topic: Option<String>,  // short headline derived from first user message
+    current_task: Option<String>, // active in-progress todo, "Doing X"
+    activity: Option<String>,     // friendly verb form of latest tool call
     name: String,        // deterministic friendly name per session
 }
 
@@ -2286,6 +2288,16 @@ struct SessionSnapshot {
     ext_counts: std::collections::HashMap<String, u32>,
     /// Tally of tool names invoked.
     tool_counts: std::collections::HashMap<String, u32>,
+    /// "Doing X" string — pulled from the latest TaskCreate/TaskUpdate
+    /// in_progress todo so the agent reads as a teammate currently
+    /// working on something specific instead of the verbatim first user
+    /// message.
+    current_task: Option<String>,
+    /// Compact verb phrase derived from the most recent tool call,
+    /// e.g. "Editing types.ts", "Reading config.yaml", "Running:
+    /// commit + push". Falls back to last_action if a friendly form is
+    /// not available.
+    activity: Option<String>,
 }
 
 fn snapshot_session(jsonl_path: &std::path::Path) -> SessionSnapshot {
@@ -2361,6 +2373,77 @@ fn snapshot_session(jsonl_path: &std::path::Path) -> SessionSnapshot {
                                 {
                                     *snap.ext_counts.entry(ext.to_lowercase()).or_insert(0) += 1;
                                 }
+                            }
+                        }
+                        // Pull the latest in-progress todo as the current
+                        // task headline. activeForm is a "doing X" sentence
+                        // already written by Claude, so it reads naturally.
+                        if matches!(name, "TaskCreate" | "TaskUpdate") {
+                            if let Some(todos) = input.get("todos").and_then(|t| t.as_array()) {
+                                let mut picked: Option<String> = None;
+                                for t in todos {
+                                    let status = t.get("status").and_then(|s| s.as_str()).unwrap_or("");
+                                    if status == "in_progress" {
+                                        let label = t.get("activeForm").and_then(|s| s.as_str())
+                                            .or_else(|| t.get("content").and_then(|s| s.as_str()))
+                                            .unwrap_or("");
+                                        if !label.is_empty() {
+                                            picked = Some(label.to_string());
+                                            break;
+                                        }
+                                    }
+                                }
+                                if picked.is_none() {
+                                    for t in todos.iter().rev() {
+                                        if t.get("status").and_then(|s| s.as_str()) == Some("pending") {
+                                            let label = t.get("content").and_then(|s| s.as_str()).unwrap_or("");
+                                            if !label.is_empty() {
+                                                picked = Some(label.to_string());
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                                if picked.is_some() {
+                                    snap.current_task = picked;
+                                }
+                            }
+                        }
+                        // Friendly verb form so the right column reads
+                        // "Editing types.ts" instead of "Bash: Read:
+                        // /long/path/types.ts".
+                        let activity = match name {
+                            "Bash" => input.get("description").and_then(|s| s.as_str())
+                                .map(|d| d.to_string())
+                                .or_else(|| input.get("command").and_then(|s| s.as_str())
+                                    .map(|c| {
+                                        let first_token = c.split_whitespace().next().unwrap_or("cmd");
+                                        format!("Running {}", first_token)
+                                    })),
+                            "Read" => input.get("file_path").and_then(|s| s.as_str())
+                                .map(|p| format!("Reading {}", basename(p))),
+                            "Edit" | "MultiEdit" => input.get("file_path").and_then(|s| s.as_str())
+                                .map(|p| format!("Editing {}", basename(p))),
+                            "Write" | "NotebookEdit" => input.get("file_path").and_then(|s| s.as_str())
+                                .map(|p| format!("Writing {}", basename(p))),
+                            "Grep" => input.get("pattern").and_then(|s| s.as_str())
+                                .map(|p| format!("Searching for {}", p)),
+                            "Glob" => input.get("pattern").and_then(|s| s.as_str())
+                                .map(|p| format!("Listing {}", p)),
+                            "WebFetch" => input.get("url").and_then(|s| s.as_str())
+                                .map(|u| format!("Fetching {}", short_host(u))),
+                            "WebSearch" => input.get("query").and_then(|s| s.as_str())
+                                .map(|q| format!("Searching web: {}", q)),
+                            "Agent" | "Task" | "TaskCreate" | "TaskUpdate" => input.get("description")
+                                .and_then(|s| s.as_str())
+                                .map(|d| format!("Planning: {}", d))
+                                .or_else(|| Some("Updating tasks".to_string())),
+                            other => Some(other.to_string()),
+                        };
+                        if let Some(a) = activity {
+                            let trimmed: String = a.split('\n').next().unwrap_or("").trim().chars().take(80).collect();
+                            if !trimmed.is_empty() {
+                                snap.activity = Some(trimmed);
                             }
                         }
                         let target = match name {
@@ -2491,6 +2574,19 @@ fn topic_from_first_msg(msg: &str) -> String {
 
 /// Read the timestamp of the first message in a jsonl session log.
 /// Used to match running PIDs to their session by start time.
+fn basename(path: &str) -> String {
+    std::path::Path::new(path)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(path)
+        .to_string()
+}
+
+fn short_host(url: &str) -> String {
+    let after_scheme = url.split("://").nth(1).unwrap_or(url);
+    after_scheme.split('/').next().unwrap_or(after_scheme).to_string()
+}
+
 fn jsonl_first_timestamp(path: &std::path::Path) -> Option<chrono::DateTime<chrono::Utc>> {
     let content = fs::read_to_string(path).ok()?;
     for line in content.lines() {
@@ -2723,6 +2819,8 @@ fn list_active_agents() -> Vec<AgentInfo> {
             role: role_label.to_string(),
             role_icon: role_icon.to_string(),
             topic,
+            current_task: snap.current_task,
+            activity: snap.activity,
             name,
         });
     }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -2145,6 +2145,7 @@ struct AgentInfo {
     session_id: Option<String>,
     jsonl_path: Option<String>,
     risk: Option<String>, // "info" | "low" | "medium" | "high" | "critical"
+    risk_events: Vec<security::SecurityEvent>,
 }
 
 /// Encode an absolute filesystem path the same way Claude Code does:
@@ -2453,13 +2454,16 @@ fn list_active_agents() -> Vec<AgentInfo> {
         // Combine fresh hits with persisted recent hits for this session so the
         // badge persists past the cursor advance.
         let session_risk = snap.session_id.as_ref().and_then(|sid| {
-            security::recent_max_severity_for_session(sid, 200)
+            security::recent_max_severity_for_session(sid, 400)
         });
         let final_risk = match (risk, session_risk) {
             (Some(a), Some(b)) => Some(if a > b { a } else { b }),
             (Some(a), None) | (None, Some(a)) => Some(a),
             _ => None,
         };
+        let risk_events = snap.session_id.as_deref()
+            .map(|sid| security::recent_events_for_session(sid, 800, 20))
+            .unwrap_or_default();
 
         let status = if kind == "claude" {
             classify_status(mtime).to_string()
@@ -2481,6 +2485,7 @@ fn list_active_agents() -> Vec<AgentInfo> {
             session_id: snap.session_id,
             jsonl_path,
             risk: final_risk.map(|s| s.as_str().to_string()),
+            risk_events,
         });
     }
 

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -2365,6 +2365,39 @@ fn snapshot_session(jsonl_path: &std::path::Path) -> SessionSnapshot {
     snap
 }
 
+/// Resolve the jsonl session log this PID is actively writing to by
+/// inspecting /proc/<pid>/fd. Falls back to None when the proc has no
+/// open jsonl handle (e.g. permissions, agent crashed). Critical for
+/// distinguishing multiple Claude agents that share the same cwd —
+/// otherwise they all read the newest jsonl and look identical.
+fn session_jsonl_for_pid(pid: u32) -> Option<(PathBuf, std::time::SystemTime)> {
+    let fd_dir = format!("/proc/{}/fd", pid);
+    let entries = fs::read_dir(&fd_dir).ok()?;
+    let mut best: Option<(PathBuf, std::time::SystemTime)> = None;
+    for entry in entries.flatten() {
+        let target = match fs::read_link(entry.path()) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        let s = target.to_string_lossy();
+        if !s.contains("/.claude/projects/") {
+            continue;
+        }
+        if target.extension().and_then(|x| x.to_str()) != Some("jsonl") {
+            continue;
+        }
+        if let Ok(meta) = fs::metadata(&target) {
+            if let Ok(m) = meta.modified() {
+                match &best {
+                    Some((_, prev)) if *prev >= m => {}
+                    _ => best = Some((target.clone(), m)),
+                }
+            }
+        }
+    }
+    best
+}
+
 fn newest_session_jsonl(cwd: &str) -> Option<(PathBuf, std::time::SystemTime)> {
     let claude_dir = get_claude_dir();
     let project_dir = claude_dir.join("projects").join(encode_project_dir(cwd));
@@ -2429,7 +2462,10 @@ fn list_active_agents() -> Vec<AgentInfo> {
             } else { None });
 
         let (jsonl_path, snap, mtime) = if kind == "claude" {
-            match newest_session_jsonl(&cwd) {
+            // Prefer the jsonl this PID is actually writing to so two agents
+            // sharing a cwd don't collapse onto the same session log.
+            let resolved = session_jsonl_for_pid(pid).or_else(|| newest_session_jsonl(&cwd));
+            match resolved {
                 Some((p, m)) => {
                     let snap = snapshot_session(&p);
                     (Some(p.to_string_lossy().to_string()), snap, Some(m))

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ use std::time::{Duration, Instant};
 use serde::{Deserialize, Serialize};
 
 mod security;
+mod egress;
 
 /// Get the Synthia project root directory.
 /// Resolves from the executable path (gui/src-tauri/target/release/synthia-gui)
@@ -2229,7 +2230,7 @@ fn classify_ai_argv(argv: &str) -> Option<&'static str> {
 }
 
 /// Returns Vec of (pid, etime_seconds, full_argv, kind).
-fn list_ai_processes(self_pid: u32) -> Vec<(u32, u64, String, &'static str)> {
+pub(crate) fn list_ai_processes(self_pid: u32) -> Vec<(u32, u64, String, &'static str)> {
     use std::process::Command;
     let output = match Command::new("ps")
         .args(["-eo", "pid=,etime=,args="])
@@ -2526,6 +2527,29 @@ fn pending_prompts_dir() -> PathBuf {
 fn prompt_responses_dir() -> PathBuf {
     let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
     PathBuf::from(home).join(".config/synthia/security/prompt-responses")
+}
+
+#[tauri::command]
+fn get_egress_enabled() -> bool {
+    egress::is_enabled()
+}
+
+#[tauri::command]
+fn set_egress_enabled(enabled: bool) -> Result<(), String> {
+    let path = egress::runtime_state_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let mut state: serde_json::Value = fs::read_to_string(&path)
+        .ok()
+        .and_then(|c| serde_json::from_str(&c).ok())
+        .unwrap_or_else(|| serde_json::json!({}));
+    if let Some(obj) = state.as_object_mut() {
+        obj.insert("egress_enabled".to_string(), serde_json::Value::Bool(enabled));
+    }
+    fs::write(&path, serde_json::to_string_pretty(&state).map_err(|e| e.to_string())?)
+        .map_err(|e| e.to_string())?;
+    Ok(())
 }
 
 #[tauri::command]
@@ -3424,6 +3448,8 @@ pub fn run() {
         std::process::exit(0);
     }
 
+    egress::spawn_watcher();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .setup(|app| {
@@ -3608,6 +3634,8 @@ pub fn run() {
             neuralguard_status,
             install_neuralguard_hooks,
             uninstall_neuralguard_hooks,
+            get_egress_enabled,
+            set_egress_enabled,
             list_hooks,
             list_plugins,
             toggle_plugin,

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -2150,6 +2150,7 @@ struct AgentInfo {
     role: String,        // "Developer" | "Technical Writer" | "Architect" | ...
     role_icon: String,   // emoji for the role
     topic: Option<String>,  // short headline derived from first user message
+    name: String,        // deterministic friendly name per session
 }
 
 /// Encode an absolute filesystem path the same way Claude Code does:
@@ -2427,27 +2428,45 @@ fn classify_role(snap: &SessionSnapshot) -> (&'static str, &'static str) {
         + *snap.tool_counts.get("EnterPlanMode").unwrap_or(&0);
 
     if total == 0 && bash_n == 0 && web_n == 0 {
-        return ("Researcher", "\u{1F50D}");
+        return ("Researcher", "\u{1F9D1}\u{200D}\u{1F52C}");
     }
     if plan_n > 0 || (web_n >= 3 && code == 0) {
-        return ("Architect", "\u{1F3D7}\u{FE0F}");
+        return ("Architect", "\u{1F9D1}\u{200D}\u{1F4BC}");
     }
     if agent_n >= 2 && code <= docs {
-        return ("Orchestrator", "\u{1F39B}\u{FE0F}");
+        return ("Orchestrator", "\u{1F9D1}\u{200D}\u{1F3A8}");
     }
     if total > 0 && docs as f32 >= (total as f32) * 0.5 {
-        return ("Technical Writer", "\u{270D}\u{FE0F}");
+        return ("Technical Writer", "\u{1F9D1}\u{200D}\u{1F3EB}");
     }
     if infra >= code && infra > 0 && bash_n >= total / 2 {
-        return ("DevOps", "\u{2699}\u{FE0F}");
+        return ("DevOps", "\u{1F9D1}\u{200D}\u{1F527}");
     }
     if code > 0 || total > 0 {
-        return ("Developer", "\u{1F468}\u{200D}\u{1F4BB}");
+        return ("Developer", "\u{1F9D1}\u{200D}\u{1F4BB}");
     }
     if bash_n > 0 || web_n > 0 {
-        return ("Researcher", "\u{1F50D}");
+        return ("Researcher", "\u{1F9D1}\u{200D}\u{1F52C}");
     }
     ("Agent", "\u{1F916}")
+}
+
+const AGENT_NAMES: &[&str] = &[
+    "Atlas", "Beckett", "Caleb", "Declan", "Elliot",
+    "Felix", "Hugo", "Jasper", "Marcus", "Wren",
+    "Aria", "Briony", "Camille", "Delphine", "Esme",
+    "Fiona", "Hazel", "Iris", "Maeve", "Sienna",
+];
+
+fn agent_name_for(seed: &str) -> &'static str {
+    // Cheap deterministic hash so the same session always gets the same name.
+    let mut h: u32 = 0x811C9DC5;
+    for b in seed.as_bytes() {
+        h ^= *b as u32;
+        h = h.wrapping_mul(0x0100_0193);
+    }
+    let idx = (h as usize) % AGENT_NAMES.len();
+    AGENT_NAMES[idx]
 }
 
 /// Trim a first-user-message into a short shareable headline.
@@ -2683,6 +2702,8 @@ fn list_active_agents() -> Vec<AgentInfo> {
 
         let (role_label, role_icon) = classify_role(&snap);
         let topic = snap.first_user_msg.as_deref().map(topic_from_first_msg);
+        let name_seed = snap.session_id.clone().unwrap_or_else(|| format!("pid:{}", pid));
+        let name = agent_name_for(&name_seed).to_string();
 
         agents.push(AgentInfo {
             pid,
@@ -2702,6 +2723,7 @@ fn list_active_agents() -> Vec<AgentInfo> {
             role: role_label.to_string(),
             role_icon: role_icon.to_string(),
             topic,
+            name,
         });
     }
 

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -2502,6 +2502,181 @@ fn clear_security_events() -> Result<(), String> {
     security::clear_events().map_err(|e| e.to_string())
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct PendingPrompt {
+    id: String,
+    ts: String,
+    tool: String,
+    raw: serde_json::Value,
+    events: Vec<serde_json::Value>,
+    agent_pid: Option<u32>,
+    timeout_s: Option<u64>,
+}
+
+fn pending_prompts_dir() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    PathBuf::from(home).join(".config/synthia/security/pending-prompts")
+}
+
+fn prompt_responses_dir() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    PathBuf::from(home).join(".config/synthia/security/prompt-responses")
+}
+
+#[tauri::command]
+fn list_pending_prompts() -> Vec<PendingPrompt> {
+    let dir = pending_prompts_dir();
+    if !dir.is_dir() {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    if let Ok(entries) = fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            if entry.path().extension().and_then(|s| s.to_str()) != Some("json") {
+                continue;
+            }
+            if let Ok(text) = fs::read_to_string(entry.path()) {
+                if let Ok(p) = serde_json::from_str::<PendingPrompt>(&text) {
+                    out.push(p);
+                }
+            }
+        }
+    }
+    out.sort_by(|a, b| a.ts.cmp(&b.ts));
+    out
+}
+
+#[tauri::command]
+fn respond_to_prompt(id: String, decision: String) -> Result<(), String> {
+    let allow = decision == "allow";
+    let dir = prompt_responses_dir();
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    let payload = serde_json::json!({
+        "id": id,
+        "decision": if allow { "allow" } else { "deny" },
+        "ts": chrono::Utc::now().to_rfc3339(),
+    });
+    let file = dir.join(format!("{}.json", id));
+    fs::write(&file, payload.to_string()).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn synthia_python_path() -> PathBuf {
+    let root = get_synthia_root();
+    root.join("venv/bin/python")
+}
+
+fn security_gate_path() -> PathBuf {
+    let root = get_synthia_root();
+    root.join("src/synthia/hooks/security_gate.py")
+}
+
+#[tauri::command]
+fn neuralguard_status() -> serde_json::Value {
+    let settings = get_settings_file();
+    let installed = match fs::read_to_string(&settings) {
+        Ok(c) => c.contains("security_gate.py"),
+        Err(_) => false,
+    };
+    serde_json::json!({
+        "installed": installed,
+        "events_path": security::events_path_for_display(),
+        "policy_path": security::policy_path_for_display(),
+        "gate_script": security_gate_path().to_string_lossy(),
+    })
+}
+
+#[tauri::command]
+fn install_neuralguard_hooks() -> Result<String, String> {
+    let settings = get_settings_file();
+    fs::create_dir_all(settings.parent().ok_or("no parent")?).map_err(|e| e.to_string())?;
+    let mut root: serde_json::Value = if settings.exists() {
+        let txt = fs::read_to_string(&settings).map_err(|e| e.to_string())?;
+        serde_json::from_str(&txt).unwrap_or_else(|_| serde_json::json!({}))
+    } else {
+        serde_json::json!({})
+    };
+    let py = synthia_python_path();
+    let gate = security_gate_path();
+    let cmd = format!("{} {}", py.to_string_lossy(), gate.to_string_lossy());
+
+    let entry = serde_json::json!({
+        "matcher": "",
+        "hooks": [
+            { "type": "command", "command": cmd, "timeout": 35 }
+        ]
+    });
+
+    for event in ["PreToolUse", "PostToolUse"] {
+        let hooks = root
+            .as_object_mut()
+            .unwrap()
+            .entry("hooks")
+            .or_insert_with(|| serde_json::json!({}))
+            .as_object_mut()
+            .ok_or("hooks not object")?;
+        let arr = hooks
+            .entry(event.to_string())
+            .or_insert_with(|| serde_json::json!([]))
+            .as_array_mut()
+            .ok_or("event not array")?;
+        // dedupe: drop existing security_gate entries first
+        arr.retain(|item| {
+            !item
+                .get("hooks")
+                .and_then(|h| h.as_array())
+                .map(|hs| {
+                    hs.iter().any(|h| {
+                        h.get("command")
+                            .and_then(|c| c.as_str())
+                            .map(|s| s.contains("security_gate.py"))
+                            .unwrap_or(false)
+                    })
+                })
+                .unwrap_or(false)
+        });
+        arr.push(entry.clone());
+    }
+
+    let serialized = serde_json::to_string_pretty(&root).map_err(|e| e.to_string())?;
+    fs::write(&settings, serialized).map_err(|e| e.to_string())?;
+    security::ensure_dir().map_err(|e| e.to_string())?;
+    Ok("NeuralGuard hooks installed".to_string())
+}
+
+#[tauri::command]
+fn uninstall_neuralguard_hooks() -> Result<String, String> {
+    let settings = get_settings_file();
+    if !settings.exists() {
+        return Ok("Nothing to remove".to_string());
+    }
+    let txt = fs::read_to_string(&settings).map_err(|e| e.to_string())?;
+    let mut root: serde_json::Value = serde_json::from_str(&txt).map_err(|e| e.to_string())?;
+    if let Some(hooks) = root.get_mut("hooks").and_then(|v| v.as_object_mut()) {
+        for event in ["PreToolUse", "PostToolUse"] {
+            if let Some(arr) = hooks.get_mut(event).and_then(|v| v.as_array_mut()) {
+                arr.retain(|item| {
+                    !item
+                        .get("hooks")
+                        .and_then(|h| h.as_array())
+                        .map(|hs| {
+                            hs.iter().any(|h| {
+                                h.get("command")
+                                    .and_then(|c| c.as_str())
+                                    .map(|s| s.contains("security_gate.py"))
+                                    .unwrap_or(false)
+                            })
+                        })
+                        .unwrap_or(false)
+                });
+            }
+        }
+    }
+    let serialized = serde_json::to_string_pretty(&root).map_err(|e| e.to_string())?;
+    fs::write(&settings, serialized).map_err(|e| e.to_string())?;
+    Ok("NeuralGuard hooks removed".to_string())
+}
+
 #[tauri::command]
 fn scan_all_sessions() -> Result<usize, String> {
     let self_pid = std::process::id();
@@ -3423,6 +3598,11 @@ pub fn run() {
             list_security_events,
             clear_security_events,
             scan_all_sessions,
+            list_pending_prompts,
+            respond_to_prompt,
+            neuralguard_status,
+            install_neuralguard_hooks,
+            uninstall_neuralguard_hooks,
             list_hooks,
             list_plugins,
             toggle_plugin,

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -13,6 +13,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 use serde::{Deserialize, Serialize};
 
+mod security;
+
 /// Get the Synthia project root directory.
 /// Resolves from the executable path (gui/src-tauri/target/release/synthia-gui)
 /// or falls back to finding run.sh relative to the binary.
@@ -2142,6 +2144,7 @@ struct AgentInfo {
     last_action: Option<String>,
     session_id: Option<String>,
     jsonl_path: Option<String>,
+    risk: Option<String>, // "info" | "low" | "medium" | "high" | "critical"
 }
 
 /// Encode an absolute filesystem path the same way Claude Code does:
@@ -2435,6 +2438,29 @@ fn list_active_agents() -> Vec<AgentInfo> {
             (None, SessionSnapshot::default(), None)
         };
 
+        let risk = if kind == "claude" {
+            jsonl_path.as_ref().and_then(|p| {
+                security::scan_session_incremental(
+                    std::path::Path::new(p),
+                    Some(pid),
+                    Some(kind),
+                    Some(&cwd),
+                )
+            })
+        } else {
+            None
+        };
+        // Combine fresh hits with persisted recent hits for this session so the
+        // badge persists past the cursor advance.
+        let session_risk = snap.session_id.as_ref().and_then(|sid| {
+            security::recent_max_severity_for_session(sid, 200)
+        });
+        let final_risk = match (risk, session_risk) {
+            (Some(a), Some(b)) => Some(if a > b { a } else { b }),
+            (Some(a), None) | (None, Some(a)) => Some(a),
+            _ => None,
+        };
+
         let status = if kind == "claude" {
             classify_status(mtime).to_string()
         } else {
@@ -2454,6 +2480,7 @@ fn list_active_agents() -> Vec<AgentInfo> {
             last_action: snap.last_action,
             session_id: snap.session_id,
             jsonl_path,
+            risk: final_risk.map(|s| s.as_str().to_string()),
         });
     }
 
@@ -2463,6 +2490,32 @@ fn list_active_agents() -> Vec<AgentInfo> {
             .then(b.started_at.cmp(&a.started_at))
     });
     agents
+}
+
+#[tauri::command]
+fn list_security_events(limit: Option<usize>) -> Vec<security::SecurityEvent> {
+    security::read_events(limit.unwrap_or(200))
+}
+
+#[tauri::command]
+fn clear_security_events() -> Result<(), String> {
+    security::clear_events().map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn scan_all_sessions() -> Result<usize, String> {
+    let self_pid = std::process::id();
+    let mut total = 0usize;
+    for (pid, _etime, _argv, kind) in list_ai_processes(self_pid) {
+        if kind != "claude" { continue; }
+        let cwd = match read_proc_cwd(pid) { Some(c) => c, None => continue };
+        if let Some((path, _)) = newest_session_jsonl(&cwd) {
+            if security::scan_session_incremental(&path, Some(pid), Some(kind), Some(&cwd)).is_some() {
+                total += 1;
+            }
+        }
+    }
+    Ok(total)
 }
 
 #[tauri::command]
@@ -3367,6 +3420,9 @@ pub fn run() {
             delete_skill,
             get_voice_muted,
             set_voice_muted,
+            list_security_events,
+            clear_security_events,
+            scan_all_sessions,
             list_hooks,
             list_plugins,
             toggle_plugin,

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -2365,37 +2365,49 @@ fn snapshot_session(jsonl_path: &std::path::Path) -> SessionSnapshot {
     snap
 }
 
-/// Resolve the jsonl session log this PID is actively writing to by
-/// inspecting /proc/<pid>/fd. Falls back to None when the proc has no
-/// open jsonl handle (e.g. permissions, agent crashed). Critical for
-/// distinguishing multiple Claude agents that share the same cwd —
-/// otherwise they all read the newest jsonl and look identical.
-fn session_jsonl_for_pid(pid: u32) -> Option<(PathBuf, std::time::SystemTime)> {
-    let fd_dir = format!("/proc/{}/fd", pid);
-    let entries = fs::read_dir(&fd_dir).ok()?;
-    let mut best: Option<(PathBuf, std::time::SystemTime)> = None;
-    for entry in entries.flatten() {
-        let target = match fs::read_link(entry.path()) {
-            Ok(t) => t,
+/// Read the timestamp of the first message in a jsonl session log.
+/// Used to match running PIDs to their session by start time.
+fn jsonl_first_timestamp(path: &std::path::Path) -> Option<chrono::DateTime<chrono::Utc>> {
+    let content = fs::read_to_string(path).ok()?;
+    for line in content.lines() {
+        let v: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
             Err(_) => continue,
         };
-        let s = target.to_string_lossy();
-        if !s.contains("/.claude/projects/") {
-            continue;
-        }
-        if target.extension().and_then(|x| x.to_str()) != Some("jsonl") {
-            continue;
-        }
-        if let Ok(meta) = fs::metadata(&target) {
-            if let Ok(m) = meta.modified() {
-                match &best {
-                    Some((_, prev)) if *prev >= m => {}
-                    _ => best = Some((target.clone(), m)),
-                }
+        if let Some(ts) = v.get("timestamp").and_then(|s| s.as_str()) {
+            if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(ts) {
+                return Some(dt.with_timezone(&chrono::Utc));
             }
         }
     }
-    best
+    None
+}
+
+/// All jsonls in the project dir for a cwd, with each one's first-message
+/// timestamp and modification mtime. Used to match running PIDs to their
+/// own session log by comparing process start_time to jsonl first-message
+/// time — needed because multiple Claude agents in the same cwd otherwise
+/// collapse onto whichever jsonl was last written to.
+fn project_jsonls(cwd: &str) -> Vec<(PathBuf, chrono::DateTime<chrono::Utc>, std::time::SystemTime)> {
+    let claude_dir = get_claude_dir();
+    let project_dir = claude_dir.join("projects").join(encode_project_dir(cwd));
+    let mut out = Vec::new();
+    if let Ok(entries) = fs::read_dir(&project_dir) {
+        for e in entries.flatten() {
+            let p = e.path();
+            if p.extension().and_then(|s| s.to_str()) != Some("jsonl") { continue; }
+            let mtime = match e.metadata().and_then(|m| m.modified()) {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
+            let first_ts = match jsonl_first_timestamp(&p) {
+                Some(t) => t,
+                None => continue,
+            };
+            out.push((p, first_ts, mtime));
+        }
+    }
+    out
 }
 
 fn newest_session_jsonl(cwd: &str) -> Option<(PathBuf, std::time::SystemTime)> {
@@ -2441,17 +2453,22 @@ fn list_active_agents() -> Vec<AgentInfo> {
     let self_pid = std::process::id();
     let mut agents = Vec::new();
 
+    // Pass 1: collect proc rows and resolve cwd, branch.
+    struct Row {
+        pid: u32,
+        etime_secs: u64,
+        kind: &'static str,
+        cwd: String,
+        branch: Option<String>,
+        started_utc: chrono::DateTime<chrono::Utc>,
+    }
+    let mut rows: Vec<Row> = Vec::new();
+    let now_utc = chrono::Utc::now();
     for (pid, etime_secs, _argv, kind) in list_ai_processes(self_pid) {
         let cwd = match read_proc_cwd(pid) {
             Some(c) => c,
             None => continue,
         };
-        let project_name = std::path::Path::new(&cwd)
-            .file_name()
-            .and_then(|s| s.to_str())
-            .unwrap_or("?")
-            .to_string();
-
         let branch = std::process::Command::new("git")
             .args(["-C", &cwd, "branch", "--show-current"])
             .output()
@@ -2460,11 +2477,62 @@ fn list_active_agents() -> Vec<AgentInfo> {
                 let s = String::from_utf8_lossy(&o.stdout).trim().to_string();
                 if s.is_empty() { None } else { Some(s) }
             } else { None });
+        let started_utc = now_utc - chrono::Duration::seconds(etime_secs as i64);
+        rows.push(Row { pid, etime_secs, kind, cwd, branch, started_utc });
+    }
+
+    // Pass 2: per-cwd, match each Claude PID to its own jsonl by closest
+    // first-message timestamp to the PID's start time. Greedy assignment
+    // so two agents in the same dir each get their own log.
+    use std::collections::HashMap;
+    let mut jsonl_for_pid: HashMap<u32, (PathBuf, std::time::SystemTime)> = HashMap::new();
+    let mut by_cwd: HashMap<String, Vec<&Row>> = HashMap::new();
+    for r in &rows {
+        if r.kind == "claude" {
+            by_cwd.entry(r.cwd.clone()).or_default().push(r);
+        }
+    }
+    for (cwd, group) in by_cwd {
+        let jsonls = project_jsonls(&cwd);
+        if jsonls.is_empty() {
+            continue;
+        }
+        // Build (pid, jsonl_idx, distance) candidates and pick greedily.
+        let mut candidates: Vec<(u32, usize, i64, PathBuf, std::time::SystemTime)> = Vec::new();
+        for r in &group {
+            for (idx, (path, first_ts, mtime)) in jsonls.iter().enumerate() {
+                let dist_ms = (r.started_utc - *first_ts).num_milliseconds().abs();
+                candidates.push((r.pid, idx, dist_ms, path.clone(), *mtime));
+            }
+        }
+        candidates.sort_by_key(|c| c.2);
+        let mut used_jsonl: std::collections::HashSet<usize> = std::collections::HashSet::new();
+        let mut used_pid: std::collections::HashSet<u32> = std::collections::HashSet::new();
+        for (pid, idx, _dist, path, mtime) in candidates {
+            if used_pid.contains(&pid) || used_jsonl.contains(&idx) {
+                continue;
+            }
+            jsonl_for_pid.insert(pid, (path, mtime));
+            used_pid.insert(pid);
+            used_jsonl.insert(idx);
+            if used_pid.len() == group.len() || used_jsonl.len() == jsonls.len() {
+                break;
+            }
+        }
+    }
+
+    for r in rows {
+        let Row { pid, etime_secs, kind, cwd, branch, .. } = r;
+        let project_name = std::path::Path::new(&cwd)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("?")
+            .to_string();
 
         let (jsonl_path, snap, mtime) = if kind == "claude" {
-            // Prefer the jsonl this PID is actually writing to so two agents
-            // sharing a cwd don't collapse onto the same session log.
-            let resolved = session_jsonl_for_pid(pid).or_else(|| newest_session_jsonl(&cwd));
+            let resolved = jsonl_for_pid
+                .remove(&pid)
+                .or_else(|| newest_session_jsonl(&cwd));
             match resolved {
                 Some((p, m)) => {
                     let snap = snapshot_session(&p);

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -2147,6 +2147,9 @@ struct AgentInfo {
     jsonl_path: Option<String>,
     risk: Option<String>, // "info" | "low" | "medium" | "high" | "critical"
     risk_events: Vec<security::SecurityEvent>,
+    role: String,        // "Developer" | "Technical Writer" | "Architect" | ...
+    role_icon: String,   // emoji for the role
+    topic: Option<String>,  // short headline derived from first user message
 }
 
 /// Encode an absolute filesystem path the same way Claude Code does:
@@ -2274,9 +2277,14 @@ pub(crate) fn list_ai_processes(self_pid: u32) -> Vec<(u32, u64, String, &'stati
 #[derive(Default)]
 struct SessionSnapshot {
     last_user_msg: Option<String>,
+    first_user_msg: Option<String>,
     last_action: Option<String>,
     session_id: Option<String>,
     last_activity: Option<String>,
+    /// Tally of file extensions touched by Edit/Write/Read tool calls.
+    ext_counts: std::collections::HashMap<String, u32>,
+    /// Tally of tool names invoked.
+    tool_counts: std::collections::HashMap<String, u32>,
 }
 
 fn snapshot_session(jsonl_path: &std::path::Path) -> SessionSnapshot {
@@ -2285,10 +2293,18 @@ fn snapshot_session(jsonl_path: &std::path::Path) -> SessionSnapshot {
         Err(_) => return SessionSnapshot::default(),
     };
     let lines: Vec<&str> = content.lines().collect();
-    let start = lines.len().saturating_sub(400);
-    let tail = &lines[start..];
+    // Read the head of the session for first_user_msg, plus the tail for
+    // current activity. Cap each side so very long sessions stay cheap.
+    let head_end = lines.len().min(40);
+    let tail_start = lines.len().saturating_sub(400);
+    let scan_ranges: Vec<&[&str]> = if tail_start > head_end {
+        vec![&lines[..head_end], &lines[tail_start..]]
+    } else {
+        vec![&lines[..]]
+    };
 
     let mut snap = SessionSnapshot::default();
+    for tail in scan_ranges.into_iter() {
     for line in tail {
         let v: serde_json::Value = match serde_json::from_str(line) {
             Ok(v) => v,
@@ -2323,7 +2339,10 @@ fn snapshot_session(jsonl_path: &std::path::Path) -> SessionSnapshot {
                 let trimmed = t.trim();
                 if !trimmed.is_empty() && !trimmed.starts_with('<') {
                     let truncated: String = trimmed.chars().take(200).collect();
-                    snap.last_user_msg = Some(truncated);
+                    snap.last_user_msg = Some(truncated.clone());
+                    if snap.first_user_msg.is_none() {
+                        snap.first_user_msg = Some(truncated);
+                    }
                 }
             }
         } else if msg_type == "assistant" {
@@ -2332,6 +2351,17 @@ fn snapshot_session(jsonl_path: &std::path::Path) -> SessionSnapshot {
                     if item.get("type").and_then(|t| t.as_str()) == Some("tool_use") {
                         let name = item.get("name").and_then(|s| s.as_str()).unwrap_or("tool");
                         let input = item.get("input").cloned().unwrap_or(serde_json::Value::Null);
+                        *snap.tool_counts.entry(name.to_string()).or_insert(0) += 1;
+                        if matches!(name, "Edit" | "Write" | "Read" | "NotebookEdit") {
+                            if let Some(p) = input.get("file_path").and_then(|s| s.as_str()) {
+                                if let Some(ext) = std::path::Path::new(p)
+                                    .extension()
+                                    .and_then(|e| e.to_str())
+                                {
+                                    *snap.ext_counts.entry(ext.to_lowercase()).or_insert(0) += 1;
+                                }
+                            }
+                        }
                         let target = match name {
                             "Bash" => input.get("description").and_then(|s| s.as_str())
                                 .or_else(|| input.get("command").and_then(|s| s.as_str())),
@@ -2362,7 +2392,82 @@ fn snapshot_session(jsonl_path: &std::path::Path) -> SessionSnapshot {
             }
         }
     }
+    }
     snap
+}
+
+/// Pick a persona for the agent based on what tools and file types it
+/// has been touching this session. Returns (role_label, emoji_avatar).
+fn classify_role(snap: &SessionSnapshot) -> (&'static str, &'static str) {
+    let docs_exts: [&str; 6] = ["md", "mdx", "rst", "txt", "adoc", "org"];
+    let code_exts: [&str; 16] = [
+        "ts", "tsx", "js", "jsx", "py", "rs", "go", "java", "rb",
+        "php", "c", "cpp", "h", "swift", "kt", "scala",
+    ];
+    let infra_exts: [&str; 8] = [
+        "yaml", "yml", "toml", "tf", "sh", "dockerfile", "ini", "conf",
+    ];
+
+    let mut docs = 0u32;
+    let mut code = 0u32;
+    let mut infra = 0u32;
+    let mut total = 0u32;
+    for (ext, n) in &snap.ext_counts {
+        total += *n;
+        if docs_exts.contains(&ext.as_str()) { docs += *n; }
+        if code_exts.contains(&ext.as_str()) { code += *n; }
+        if infra_exts.contains(&ext.as_str()) { infra += *n; }
+    }
+    let bash_n = *snap.tool_counts.get("Bash").unwrap_or(&0);
+    let web_n = *snap.tool_counts.get("WebFetch").unwrap_or(&0)
+        + *snap.tool_counts.get("WebSearch").unwrap_or(&0);
+    let agent_n = *snap.tool_counts.get("Agent").unwrap_or(&0)
+        + *snap.tool_counts.get("Task").unwrap_or(&0);
+    let plan_n = *snap.tool_counts.get("ExitPlanMode").unwrap_or(&0)
+        + *snap.tool_counts.get("EnterPlanMode").unwrap_or(&0);
+
+    if total == 0 && bash_n == 0 && web_n == 0 {
+        return ("Researcher", "\u{1F50D}");
+    }
+    if plan_n > 0 || (web_n >= 3 && code == 0) {
+        return ("Architect", "\u{1F3D7}\u{FE0F}");
+    }
+    if agent_n >= 2 && code <= docs {
+        return ("Orchestrator", "\u{1F39B}\u{FE0F}");
+    }
+    if total > 0 && docs as f32 >= (total as f32) * 0.5 {
+        return ("Technical Writer", "\u{270D}\u{FE0F}");
+    }
+    if infra >= code && infra > 0 && bash_n >= total / 2 {
+        return ("DevOps", "\u{2699}\u{FE0F}");
+    }
+    if code > 0 || total > 0 {
+        return ("Developer", "\u{1F468}\u{200D}\u{1F4BB}");
+    }
+    if bash_n > 0 || web_n > 0 {
+        return ("Researcher", "\u{1F50D}");
+    }
+    ("Agent", "\u{1F916}")
+}
+
+/// Trim a first-user-message into a short shareable headline.
+fn topic_from_first_msg(msg: &str) -> String {
+    let cleaned: String = msg
+        .lines()
+        .filter(|l| {
+            let t = l.trim();
+            !t.is_empty() && !t.starts_with('<') && !t.starts_with('#')
+        })
+        .collect::<Vec<&str>>()
+        .join(" ")
+        .chars()
+        .take(140)
+        .collect();
+    if cleaned.is_empty() {
+        msg.chars().take(140).collect()
+    } else {
+        cleaned
+    }
 }
 
 /// Read the timestamp of the first message in a jsonl session log.
@@ -2576,6 +2681,9 @@ fn list_active_agents() -> Vec<AgentInfo> {
             "active".to_string()
         };
 
+        let (role_label, role_icon) = classify_role(&snap);
+        let topic = snap.first_user_msg.as_deref().map(topic_from_first_msg);
+
         agents.push(AgentInfo {
             pid,
             kind: kind.to_string(),
@@ -2591,6 +2699,9 @@ fn list_active_agents() -> Vec<AgentInfo> {
             jsonl_path,
             risk: final_risk.map(|s| s.as_str().to_string()),
             risk_events,
+            role: role_label.to_string(),
+            role_icon: role_icon.to_string(),
+            topic,
         });
     }
 

--- a/gui/src-tauri/src/security.rs
+++ b/gui/src-tauri/src/security.rs
@@ -111,84 +111,228 @@ pub fn evaluate_tool(tool: &str, input: &Value) -> Vec<RuleHit> {
     hits
 }
 
+// Binaries whose args are usually quoted strings or scripts, not real
+// commands. Skip binary-bound rules for the entire statement when one of
+// these is the head binary.
+fn is_quoting_binary(name: &str) -> bool {
+    matches!(
+        name,
+        "echo" | "printf" | "gh" | "git" | "jq" | "awk" | "sed"
+            | "python" | "python3" | "node" | "ruby" | "perl"
+    )
+}
+
+fn split_statements(cmd: &str) -> Vec<&str> {
+    // Split on `;`, `&&`, `||`. NOT on `|` — pipelines remain intact for
+    // statement-level rules.
+    let mut out = Vec::new();
+    let bytes = cmd.as_bytes();
+    let mut start = 0usize;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let b = bytes[i];
+        let split_len = if b == b';' {
+            1
+        } else if i + 1 < bytes.len()
+            && ((b == b'&' && bytes[i + 1] == b'&')
+                || (b == b'|' && bytes[i + 1] == b'|'))
+        {
+            2
+        } else {
+            0
+        };
+        if split_len > 0 {
+            let part = cmd[start..i].trim();
+            if !part.is_empty() {
+                out.push(part);
+            }
+            i += split_len;
+            start = i;
+            continue;
+        }
+        i += 1;
+    }
+    let last = cmd[start..].trim();
+    if !last.is_empty() {
+        out.push(last);
+    }
+    out
+}
+
+fn split_pipeline(stmt: &str) -> Vec<&str> {
+    // Split on `|` but skip `||`.
+    let mut out = Vec::new();
+    let bytes = stmt.as_bytes();
+    let mut start = 0usize;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if bytes[i] == b'|' && (i + 1 >= bytes.len() || bytes[i + 1] != b'|')
+            && (i == 0 || bytes[i - 1] != b'|')
+        {
+            let part = stmt[start..i].trim();
+            if !part.is_empty() {
+                out.push(part);
+            }
+            i += 1;
+            start = i;
+            continue;
+        }
+        i += 1;
+    }
+    let last = stmt[start..].trim();
+    if !last.is_empty() {
+        out.push(last);
+    }
+    out
+}
+
+fn shlex_split(s: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut cur = String::new();
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            '\\' if !in_single => {
+                if let Some(&next) = chars.peek() {
+                    cur.push(next);
+                    chars.next();
+                }
+            }
+            c if c.is_whitespace() && !in_single && !in_double => {
+                if !cur.is_empty() {
+                    out.push(std::mem::take(&mut cur));
+                }
+            }
+            _ => cur.push(c),
+        }
+    }
+    if !cur.is_empty() {
+        out.push(cur);
+    }
+    out
+}
+
+fn is_env_assign(tok: &str) -> bool {
+    let bytes = tok.as_bytes();
+    if bytes.is_empty() {
+        return false;
+    }
+    let first = bytes[0];
+    if !(first.is_ascii_alphabetic() || first == b'_') {
+        return false;
+    }
+    for (i, &b) in bytes.iter().enumerate() {
+        if b == b'=' {
+            return i > 0;
+        }
+        if !(b.is_ascii_alphanumeric() || b == b'_') {
+            return false;
+        }
+    }
+    false
+}
+
+fn binary_of(segment: &str) -> Option<(String, String)> {
+    let mut tokens = shlex_split(segment);
+    while !tokens.is_empty() && is_env_assign(&tokens[0]) {
+        tokens.remove(0);
+    }
+    if tokens.is_empty() {
+        return None;
+    }
+    let bin_full = tokens.remove(0);
+    let basename = std::path::Path::new(&bin_full)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(&bin_full)
+        .to_string();
+    Some((basename, tokens.join(" ")))
+}
+
+// (rule, severity, &[binary basenames], optional arg-pattern)
+type BinRule = (&'static str, Severity, &'static [&'static str], Option<&'static str>);
+
+const BASH_RULES: &[BinRule] = &[
+    ("destructive-rm", Severity::Critical, &["rm"], Some(r"-[rR]f?\b.*(?:^|\s)(/|~|\$home|--no-preserve-root)")),
+    ("dd-block-device", Severity::Critical, &["dd"], Some(r"of=/dev/(sd|nvme|hd)")),
+    ("setuid-bit", Severity::High, &["chmod"], Some(r"\+s\b")),
+    ("setcap", Severity::High, &["setcap"], None),
+    ("ssh-key-access", Severity::High, &["cat", "less", "more", "head", "tail", "cp", "mv", "rm"], Some(r"~?/?\.ssh/(id_|authorized_keys|known_hosts)")),
+    ("gpg-access", Severity::High, &["cat", "less", "more", "head", "tail", "cp", "mv", "rm", "tar", "zip"], Some(r"~?/?\.gnupg/")),
+    ("aws-credentials", Severity::High, &["cat", "less", "more", "head", "tail", "cp", "mv"], Some(r"~?/?\.aws/credentials")),
+    ("secret-exfil", Severity::Critical, &["curl", "wget", "scp", "rsync"], Some(r"(\.ssh|\.aws|\.gnupg|credentials|secret|token|api[_-]?key)")),
+    ("mass-kill", Severity::Medium, &["pkill", "killall"], Some(r"-9\b")),
+    ("git-remote-rewrite", Severity::Medium, &["git"], Some(r"\bremote\s+(set-url|add)\s+\S+\s+(https?:|git@)")),
+    ("history-tamper", Severity::Medium, &["history"], Some(r"-c\b")),
+];
+
+const STMT_RULES: &[(&'static str, Severity, &'static str)] = &[
+    ("pipe-to-shell", Severity::Critical, r"(?:^|[\s;&|])(curl|wget|fetch)\b[^|]*\|\s*(sh|bash|zsh|fish)\b"),
+    ("base64-exec", Severity::Critical, r"\bbase64\s+(-d|--decode)\b[^|]*\|\s*(sh|bash|python|node)\b"),
+    ("shell-rc-tamper", Severity::High, r">>?\s*~?/?\.(bashrc|zshrc|profile|bash_profile|zprofile)\b"),
+    ("history-redir-tamper", Severity::Medium, r">\s*~?/?\.(bash_history|zsh_history)\b"),
+    ("sudo", Severity::High, r"(?:^|[\s;&|])sudo\b"),
+];
+
 fn evaluate_bash(cmd: &str) -> Vec<RuleHit> {
-    let mut hits = Vec::new();
-    let lower = cmd.to_lowercase();
+    let mut hits: Vec<RuleHit> = Vec::new();
+    let mut seen: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
 
-    // Destructive rm
-    if let Some(m) = match_first(&lower, &[
-        r"rm\s+-rf?\s+/",
-        r"rm\s+-rf?\s+~",
-        r"rm\s+-rf?\s+\$home",
-        r"rm\s+-rf?\s+--no-preserve-root",
-    ]) {
-        hits.push(RuleHit { rule: "destructive-rm", severity: Severity::Critical, matched: m });
-    }
+    let mut emit = |rule: &'static str, sev: Severity, matched: String,
+                    seen: &mut std::collections::HashSet<(String, String)>,
+                    hits: &mut Vec<RuleHit>| {
+        let key = (rule.to_string(), matched.clone());
+        if seen.insert(key) {
+            hits.push(RuleHit { rule, severity: sev, matched });
+        }
+    };
 
-    // dd to block device
-    if regex_match(&lower, r"\bdd\b.+of=/dev/(sd|nvme|hd)") {
-        hits.push(RuleHit { rule: "dd-block-device", severity: Severity::Critical, matched: "dd of=/dev/...".to_string() });
-    }
+    let lower_full = cmd.to_lowercase();
+    for stmt in split_statements(&lower_full) {
+        // statement-level rules (full pipeline visible)
+        for (rule, sev, pat) in STMT_RULES {
+            if let Ok(re) = regex::Regex::new(pat) {
+                if let Some(m) = re.find(stmt) {
+                    emit(rule, *sev, m.as_str().to_string(), &mut seen, &mut hits);
+                }
+            }
+        }
 
-    // Pipe to shell
-    if regex_match(&lower, r"(curl|wget|fetch)[^|]*\|\s*(sh|bash|zsh|fish)\b") {
-        hits.push(RuleHit { rule: "pipe-to-shell", severity: Severity::Critical, matched: "curl/wget | sh".to_string() });
-    }
+        let head = binary_of(stmt).map(|(b, _)| b);
+        if head.as_deref().map(is_quoting_binary).unwrap_or(false) {
+            continue;
+        }
 
-    // Base64 + exec
-    if regex_match(&lower, r"base64\s+(-d|--decode)[^|]*\|\s*(sh|bash|python|node)") {
-        hits.push(RuleHit { rule: "base64-exec", severity: Severity::Critical, matched: "base64 -d | sh".to_string() });
+        for stage in split_pipeline(stmt) {
+            let (binary, args) = match binary_of(stage) {
+                Some(t) => t,
+                None => continue,
+            };
+            if is_quoting_binary(&binary) {
+                continue;
+            }
+            for (rule, sev, bins, pat) in BASH_RULES {
+                if !bins.contains(&binary.as_str()) {
+                    continue;
+                }
+                let matched = match pat {
+                    None => binary.clone(),
+                    Some(p) => match regex::Regex::new(p)
+                        .ok()
+                        .and_then(|r| r.find(&args).map(|m| m.as_str().to_string()))
+                    {
+                        Some(s) => s,
+                        None => continue,
+                    },
+                };
+                emit(rule, *sev, matched, &mut seen, &mut hits);
+            }
+        }
     }
-
-    // Privilege escalation
-    if regex_match(&lower, r"\bsudo\b") {
-        hits.push(RuleHit { rule: "sudo", severity: Severity::High, matched: "sudo".to_string() });
-    }
-    if regex_match(&lower, r"chmod\s+\+s\b") {
-        hits.push(RuleHit { rule: "setuid-bit", severity: Severity::High, matched: "chmod +s".to_string() });
-    }
-    if regex_match(&lower, r"\bsetcap\b") {
-        hits.push(RuleHit { rule: "setcap", severity: Severity::High, matched: "setcap".to_string() });
-    }
-
-    // Shell-rc tamper
-    if regex_match(&lower, r">+\s*~?/?\.(bashrc|zshrc|profile|bash_profile|zprofile)\b") {
-        hits.push(RuleHit { rule: "shell-rc-tamper", severity: Severity::High, matched: "rc-file write".to_string() });
-    }
-
-    // SSH key read
-    if regex_match(&lower, r"~?/?\.ssh/(id_|authorized_keys|known_hosts)") {
-        hits.push(RuleHit { rule: "ssh-key-access", severity: Severity::High, matched: "~/.ssh/...".to_string() });
-    }
-
-    // GPG / credentials
-    if regex_match(&lower, r"~?/?\.gnupg/") {
-        hits.push(RuleHit { rule: "gpg-access", severity: Severity::High, matched: "~/.gnupg/...".to_string() });
-    }
-    if regex_match(&lower, r"~?/?\.aws/credentials") {
-        hits.push(RuleHit { rule: "aws-credentials", severity: Severity::High, matched: "~/.aws/credentials".to_string() });
-    }
-
-    // Network exfil pattern: tar/zip + curl/scp to non-localhost
-    if regex_match(&lower, r"(curl|wget|scp|rsync)[^|;&\n]*(\.ssh|\.aws|\.gnupg|credentials|secret|token)") {
-        hits.push(RuleHit { rule: "secret-exfil", severity: Severity::Critical, matched: "secret + network".to_string() });
-    }
-
-    // Mass kill
-    if regex_match(&lower, r"\bpkill\s+-9\b|\bkillall\s+-9\b") {
-        hits.push(RuleHit { rule: "mass-kill", severity: Severity::Medium, matched: "pkill -9".to_string() });
-    }
-
-    // Git remote rewrite
-    if regex_match(&lower, r"git\s+remote\s+(set-url|add)\s+\S+\s+(http|git@)") {
-        hits.push(RuleHit { rule: "git-remote-rewrite", severity: Severity::Medium, matched: "git remote set-url".to_string() });
-    }
-
-    // History tamper
-    if regex_match(&lower, r"history\s+-c|>\s*~?/?\.(bash_history|zsh_history)") {
-        hits.push(RuleHit { rule: "history-tamper", severity: Severity::Medium, matched: "history clear".to_string() });
-    }
-
     hits
 }
 

--- a/gui/src-tauri/src/security.rs
+++ b/gui/src-tauri/src/security.rs
@@ -1,0 +1,435 @@
+//! NeuralGuard security layer.
+//!
+//! Phase 1 (rules-based): scans tool_use entries from Claude session jsonl,
+//! emits SecurityEvent records when a rule matches, persists them to
+//! ~/.config/synthia/security/events.jsonl, and exposes Tauri commands.
+
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Info,
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+impl Severity {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Severity::Info => "info",
+            Severity::Low => "low",
+            Severity::Medium => "medium",
+            Severity::High => "high",
+            Severity::Critical => "critical",
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SecurityEvent {
+    pub id: String,
+    pub ts: String,
+    pub agent_pid: Option<u32>,
+    pub agent_kind: Option<String>,
+    pub agent_cwd: Option<String>,
+    pub session_id: Option<String>,
+    pub tool: String,
+    pub rule: String,
+    pub severity: Severity,
+    pub matched: String,
+    pub raw: Value,
+    pub decision: String,
+    pub actor: String,
+}
+
+pub struct RuleHit {
+    pub rule: &'static str,
+    pub severity: Severity,
+    pub matched: String,
+}
+
+fn security_dir() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    PathBuf::from(home).join(".config/synthia/security")
+}
+
+fn events_path() -> PathBuf {
+    security_dir().join("events.jsonl")
+}
+
+fn cursor_path() -> PathBuf {
+    security_dir().join("cursors.json")
+}
+
+pub fn ensure_dir() -> std::io::Result<()> {
+    fs::create_dir_all(security_dir())
+}
+
+/// Returns Vec<RuleHit> for a given tool_use input. Empty on clean.
+pub fn evaluate_tool(tool: &str, input: &Value) -> Vec<RuleHit> {
+    let mut hits = Vec::new();
+    match tool {
+        "Bash" => {
+            if let Some(cmd) = input.get("command").and_then(|v| v.as_str()) {
+                hits.extend(evaluate_bash(cmd));
+            }
+        }
+        "Write" | "Edit" | "NotebookEdit" => {
+            if let Some(path) = input.get("file_path").and_then(|v| v.as_str()) {
+                hits.extend(evaluate_write(path));
+            }
+        }
+        "Read" => {
+            if let Some(path) = input.get("file_path").and_then(|v| v.as_str()) {
+                hits.extend(evaluate_read(path));
+            }
+        }
+        "WebFetch" => {
+            if let Some(url) = input.get("url").and_then(|v| v.as_str()) {
+                hits.extend(evaluate_fetch(url));
+            }
+        }
+        _ => {}
+    }
+    hits
+}
+
+fn evaluate_bash(cmd: &str) -> Vec<RuleHit> {
+    let mut hits = Vec::new();
+    let lower = cmd.to_lowercase();
+
+    // Destructive rm
+    if let Some(m) = match_first(&lower, &[
+        r"rm\s+-rf?\s+/",
+        r"rm\s+-rf?\s+~",
+        r"rm\s+-rf?\s+\$home",
+        r"rm\s+-rf?\s+--no-preserve-root",
+    ]) {
+        hits.push(RuleHit { rule: "destructive-rm", severity: Severity::Critical, matched: m });
+    }
+
+    // dd to block device
+    if regex_match(&lower, r"\bdd\b.+of=/dev/(sd|nvme|hd)") {
+        hits.push(RuleHit { rule: "dd-block-device", severity: Severity::Critical, matched: "dd of=/dev/...".to_string() });
+    }
+
+    // Pipe to shell
+    if regex_match(&lower, r"(curl|wget|fetch)[^|]*\|\s*(sh|bash|zsh|fish)\b") {
+        hits.push(RuleHit { rule: "pipe-to-shell", severity: Severity::Critical, matched: "curl/wget | sh".to_string() });
+    }
+
+    // Base64 + exec
+    if regex_match(&lower, r"base64\s+(-d|--decode)[^|]*\|\s*(sh|bash|python|node)") {
+        hits.push(RuleHit { rule: "base64-exec", severity: Severity::Critical, matched: "base64 -d | sh".to_string() });
+    }
+
+    // Privilege escalation
+    if regex_match(&lower, r"\bsudo\b") {
+        hits.push(RuleHit { rule: "sudo", severity: Severity::High, matched: "sudo".to_string() });
+    }
+    if regex_match(&lower, r"chmod\s+\+s\b") {
+        hits.push(RuleHit { rule: "setuid-bit", severity: Severity::High, matched: "chmod +s".to_string() });
+    }
+    if regex_match(&lower, r"\bsetcap\b") {
+        hits.push(RuleHit { rule: "setcap", severity: Severity::High, matched: "setcap".to_string() });
+    }
+
+    // Shell-rc tamper
+    if regex_match(&lower, r">+\s*~?/?\.(bashrc|zshrc|profile|bash_profile|zprofile)\b") {
+        hits.push(RuleHit { rule: "shell-rc-tamper", severity: Severity::High, matched: "rc-file write".to_string() });
+    }
+
+    // SSH key read
+    if regex_match(&lower, r"~?/?\.ssh/(id_|authorized_keys|known_hosts)") {
+        hits.push(RuleHit { rule: "ssh-key-access", severity: Severity::High, matched: "~/.ssh/...".to_string() });
+    }
+
+    // GPG / credentials
+    if regex_match(&lower, r"~?/?\.gnupg/") {
+        hits.push(RuleHit { rule: "gpg-access", severity: Severity::High, matched: "~/.gnupg/...".to_string() });
+    }
+    if regex_match(&lower, r"~?/?\.aws/credentials") {
+        hits.push(RuleHit { rule: "aws-credentials", severity: Severity::High, matched: "~/.aws/credentials".to_string() });
+    }
+
+    // Network exfil pattern: tar/zip + curl/scp to non-localhost
+    if regex_match(&lower, r"(curl|wget|scp|rsync)[^|;&\n]*(\.ssh|\.aws|\.gnupg|credentials|secret|token)") {
+        hits.push(RuleHit { rule: "secret-exfil", severity: Severity::Critical, matched: "secret + network".to_string() });
+    }
+
+    // Mass kill
+    if regex_match(&lower, r"\bpkill\s+-9\b|\bkillall\s+-9\b") {
+        hits.push(RuleHit { rule: "mass-kill", severity: Severity::Medium, matched: "pkill -9".to_string() });
+    }
+
+    // Git remote rewrite
+    if regex_match(&lower, r"git\s+remote\s+(set-url|add)\s+\S+\s+(http|git@)") {
+        hits.push(RuleHit { rule: "git-remote-rewrite", severity: Severity::Medium, matched: "git remote set-url".to_string() });
+    }
+
+    // History tamper
+    if regex_match(&lower, r"history\s+-c|>\s*~?/?\.(bash_history|zsh_history)") {
+        hits.push(RuleHit { rule: "history-tamper", severity: Severity::Medium, matched: "history clear".to_string() });
+    }
+
+    hits
+}
+
+fn evaluate_write(path: &str) -> Vec<RuleHit> {
+    let lower = path.to_lowercase();
+    let mut hits = Vec::new();
+    if regex_match(&lower, r"\.ssh/(id_|authorized_keys)") {
+        hits.push(RuleHit { rule: "ssh-key-write", severity: Severity::Critical, matched: path.to_string() });
+    }
+    if regex_match(&lower, r"\.(bashrc|zshrc|profile|bash_profile|zprofile)$") {
+        hits.push(RuleHit { rule: "shell-rc-write", severity: Severity::High, matched: path.to_string() });
+    }
+    if regex_match(&lower, r"\.env(\.|$)") {
+        hits.push(RuleHit { rule: "env-file-write", severity: Severity::Medium, matched: path.to_string() });
+    }
+    if regex_match(&lower, r"^/etc/") {
+        hits.push(RuleHit { rule: "system-config-write", severity: Severity::High, matched: path.to_string() });
+    }
+    hits
+}
+
+fn evaluate_read(path: &str) -> Vec<RuleHit> {
+    let lower = path.to_lowercase();
+    let mut hits = Vec::new();
+    if regex_match(&lower, r"\.ssh/(id_|authorized_keys)") {
+        hits.push(RuleHit { rule: "ssh-key-read", severity: Severity::High, matched: path.to_string() });
+    }
+    if regex_match(&lower, r"\.aws/credentials|\.gnupg/") {
+        hits.push(RuleHit { rule: "credentials-read", severity: Severity::High, matched: path.to_string() });
+    }
+    hits
+}
+
+fn evaluate_fetch(url: &str) -> Vec<RuleHit> {
+    let lower = url.to_lowercase();
+    let mut hits = Vec::new();
+    // very loose IP-literal (often shellcode hosting)
+    if regex_match(&lower, r"^https?://\d+\.\d+\.\d+\.\d+") {
+        hits.push(RuleHit { rule: "fetch-ip-literal", severity: Severity::Medium, matched: url.to_string() });
+    }
+    if regex_match(&lower, r"\.onion/") {
+        hits.push(RuleHit { rule: "fetch-onion", severity: Severity::High, matched: url.to_string() });
+    }
+    hits
+}
+
+/// Scan a string of text (e.g. tool result) for prompt-injection signatures.
+pub fn evaluate_injection(text: &str) -> Vec<RuleHit> {
+    let mut hits = Vec::new();
+    let lower = text.to_lowercase();
+    if regex_match(&lower, r"ignore\s+(all\s+)?previous\s+instructions") {
+        hits.push(RuleHit { rule: "injection-ignore-previous", severity: Severity::High, matched: "ignore previous instructions".to_string() });
+    }
+    if regex_match(&lower, r"you\s+are\s+now\s+(a\s+)?[a-z\s]{0,30}(jailbreak|developer\s*mode|dan)") {
+        hits.push(RuleHit { rule: "injection-roleplay", severity: Severity::High, matched: "roleplay/jailbreak".to_string() });
+    }
+    if regex_match(text, r"\[SYSTEM\]|<system>|###\s*system\s*###") {
+        hits.push(RuleHit { rule: "injection-system-marker", severity: Severity::Medium, matched: "system marker".to_string() });
+    }
+    // Hidden unicode tag/zero-width
+    if text.chars().any(|c| matches!(c as u32, 0x200B..=0x200F | 0xE0000..=0xE007F)) {
+        hits.push(RuleHit { rule: "injection-hidden-unicode", severity: Severity::High, matched: "zero-width chars".to_string() });
+    }
+    hits
+}
+
+fn regex_match(text: &str, pattern: &str) -> bool {
+    regex::Regex::new(pattern).map(|r| r.is_match(text)).unwrap_or(false)
+}
+
+fn match_first(text: &str, patterns: &[&str]) -> Option<String> {
+    for p in patterns {
+        if let Ok(r) = regex::Regex::new(p) {
+            if let Some(m) = r.find(text) {
+                return Some(m.as_str().to_string());
+            }
+        }
+    }
+    None
+}
+
+fn random_id() -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("evt_{:x}", nanos)
+}
+
+pub fn make_event(
+    hit: RuleHit,
+    tool: &str,
+    raw: Value,
+    agent_pid: Option<u32>,
+    agent_kind: Option<&str>,
+    agent_cwd: Option<&str>,
+    session_id: Option<&str>,
+    decision: &str,
+    actor: &str,
+) -> SecurityEvent {
+    SecurityEvent {
+        id: random_id(),
+        ts: Utc::now().to_rfc3339(),
+        agent_pid,
+        agent_kind: agent_kind.map(|s| s.to_string()),
+        agent_cwd: agent_cwd.map(|s| s.to_string()),
+        session_id: session_id.map(|s| s.to_string()),
+        tool: tool.to_string(),
+        rule: hit.rule.to_string(),
+        severity: hit.severity,
+        matched: hit.matched,
+        raw,
+        decision: decision.to_string(),
+        actor: actor.to_string(),
+    }
+}
+
+pub fn append_events(events: &[SecurityEvent]) -> std::io::Result<()> {
+    if events.is_empty() {
+        return Ok(());
+    }
+    ensure_dir()?;
+    let path = events_path();
+    let mut f = OpenOptions::new().create(true).append(true).open(&path)?;
+    for e in events {
+        let line = serde_json::to_string(e).unwrap_or_default();
+        writeln!(f, "{}", line)?;
+    }
+    Ok(())
+}
+
+pub fn recent_max_severity_for_session(session_id: &str, scan_limit: usize) -> Option<Severity> {
+    let path = events_path();
+    let content = fs::read_to_string(&path).ok()?;
+    let mut max_sev: Option<Severity> = None;
+    for line in content.lines().rev().take(scan_limit) {
+        if let Ok(e) = serde_json::from_str::<SecurityEvent>(line) {
+            if e.session_id.as_deref() == Some(session_id) {
+                if max_sev.map(|m| e.severity > m).unwrap_or(true) {
+                    max_sev = Some(e.severity);
+                }
+            }
+        }
+    }
+    max_sev
+}
+
+pub fn read_events(limit: usize) -> Vec<SecurityEvent> {
+    let path = events_path();
+    let content = match fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    let mut out: Vec<SecurityEvent> = content
+        .lines()
+        .rev()
+        .take(limit)
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .collect();
+    out.reverse();
+    out
+}
+
+pub fn clear_events() -> std::io::Result<()> {
+    let path = events_path();
+    if path.exists() {
+        fs::remove_file(&path)?;
+    }
+    Ok(())
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, Default)]
+struct Cursors(std::collections::HashMap<String, u64>);
+
+fn load_cursors() -> Cursors {
+    fs::read_to_string(cursor_path())
+        .ok()
+        .and_then(|c| serde_json::from_str(&c).ok())
+        .unwrap_or_default()
+}
+
+fn save_cursors(c: &Cursors) -> std::io::Result<()> {
+    ensure_dir()?;
+    let s = serde_json::to_string(c).unwrap_or_default();
+    fs::write(cursor_path(), s)
+}
+
+/// Scan a session jsonl from the last cursor onward, evaluate each tool_use,
+/// emit events, and persist new cursor. Returns the max severity seen in this
+/// scan (None if no hits).
+pub fn scan_session_incremental(
+    session_path: &std::path::Path,
+    agent_pid: Option<u32>,
+    agent_kind: Option<&str>,
+    agent_cwd: Option<&str>,
+) -> Option<Severity> {
+    let key = session_path.to_string_lossy().to_string();
+    let mut cursors = load_cursors();
+    let start = *cursors.0.get(&key).unwrap_or(&0);
+    let content = match fs::read_to_string(session_path) {
+        Ok(c) => c,
+        Err(_) => return None,
+    };
+    let mut new_events = Vec::new();
+    let mut max_sev: Option<Severity> = None;
+    let mut line_idx: u64 = 0;
+    for line in content.lines() {
+        line_idx += 1;
+        if line_idx <= start {
+            continue;
+        }
+        let v: Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let session_id = v.get("sessionId").and_then(|s| s.as_str());
+        if v.get("type").and_then(|t| t.as_str()) != Some("assistant") {
+            continue;
+        }
+        let content_arr = match v.get("message").and_then(|m| m.get("content")).and_then(|c| c.as_array()) {
+            Some(arr) => arr,
+            None => continue,
+        };
+        for item in content_arr {
+            if item.get("type").and_then(|t| t.as_str()) != Some("tool_use") {
+                continue;
+            }
+            let name = item.get("name").and_then(|s| s.as_str()).unwrap_or("");
+            let input = item.get("input").cloned().unwrap_or(Value::Null);
+            for hit in evaluate_tool(name, &input) {
+                if max_sev.map(|m| hit.severity > m).unwrap_or(true) {
+                    max_sev = Some(hit.severity);
+                }
+                new_events.push(make_event(
+                    hit,
+                    name,
+                    input.clone(),
+                    agent_pid,
+                    agent_kind,
+                    agent_cwd,
+                    session_id,
+                    "observed",
+                    "rule-engine",
+                ));
+            }
+        }
+    }
+    cursors.0.insert(key, line_idx);
+    let _ = save_cursors(&cursors);
+    let _ = append_events(&new_events);
+    max_sev
+}

--- a/gui/src-tauri/src/security.rs
+++ b/gui/src-tauri/src/security.rs
@@ -74,6 +74,14 @@ pub fn ensure_dir() -> std::io::Result<()> {
     fs::create_dir_all(security_dir())
 }
 
+pub fn events_path_for_display() -> String {
+    events_path().to_string_lossy().to_string()
+}
+
+pub fn policy_path_for_display() -> String {
+    security_dir().join("policy.yaml").to_string_lossy().to_string()
+}
+
 /// Returns Vec<RuleHit> for a given tool_use input. Empty on clean.
 pub fn evaluate_tool(tool: &str, input: &Value) -> Vec<RuleHit> {
     let mut hits = Vec::new();

--- a/gui/src-tauri/src/security.rs
+++ b/gui/src-tauri/src/security.rs
@@ -464,6 +464,27 @@ pub fn append_events(events: &[SecurityEvent]) -> std::io::Result<()> {
     Ok(())
 }
 
+pub fn recent_events_for_session(session_id: &str, scan_limit: usize, take: usize) -> Vec<SecurityEvent> {
+    let path = events_path();
+    let content = match fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    let mut out: Vec<SecurityEvent> = Vec::new();
+    for line in content.lines().rev().take(scan_limit) {
+        if let Ok(e) = serde_json::from_str::<SecurityEvent>(line) {
+            if e.session_id.as_deref() == Some(session_id) {
+                out.push(e);
+                if out.len() >= take {
+                    break;
+                }
+            }
+        }
+    }
+    out.reverse();
+    out
+}
+
 pub fn recent_max_severity_for_session(session_id: &str, scan_limit: usize) -> Option<Severity> {
     let path = events_path();
     let content = fs::read_to_string(&path).ok()?;

--- a/gui/src/App.css
+++ b/gui/src/App.css
@@ -4393,6 +4393,52 @@
 .agent-project { font-weight: 600; }
 .agent-cwd     { color: var(--text-muted, #888); font-family: monospace; font-size: 0.8em; }
 .agent-branch  { color: var(--text-muted, #888); font-family: monospace; font-size: 0.85em; }
+.agent-avatar {
+  font-size: 1.5rem;
+  line-height: 1;
+  width: 2.25rem;
+  height: 2.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: rgba(125, 211, 252, 0.08);
+  border: 1px solid rgba(125, 211, 252, 0.18);
+  flex-shrink: 0;
+}
+.agent-identity {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.agent-identity-line {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: nowrap;
+}
+.agent-role {
+  font-size: 0.72em;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  color: #7dd3fc;
+  padding: 0.05rem 0.4rem;
+  border-radius: 0.25rem;
+  background: rgba(125, 211, 252, 0.1);
+  border: 1px solid rgba(125, 211, 252, 0.25);
+}
+.agent-topic {
+  font-size: 0.82rem;
+  color: #cbd5e1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-style: italic;
+  max-width: 100%;
+}
 .agent-kind {
   font-size: 0.7em;
   text-transform: uppercase;

--- a/gui/src/App.css
+++ b/gui/src/App.css
@@ -4564,6 +4564,18 @@
 .security-explain strong { color: #e2e8f0; }
 .security-explain > div + div { margin-top: 0.25rem; }
 
+.outcome-pill {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.1rem 0.5rem;
+  border-radius: 0.25rem;
+  letter-spacing: 0.02em;
+}
+.outcome-blocked   { background: rgba(74, 222, 128, 0.15); color: #4ade80; border: 1px solid rgba(74, 222, 128, 0.35); }
+.outcome-ran-warn  { background: rgba(251, 146, 60, 0.15); color: #fb923c; border: 1px solid rgba(251, 146, 60, 0.35); }
+.outcome-ran-info  { background: rgba(125, 211, 252, 0.12); color: #7dd3fc; border: 1px solid rgba(125, 211, 252, 0.30); }
+.outcome-pending   { background: rgba(251, 191, 36, 0.15); color: #fbbf24; border: 1px solid rgba(251, 191, 36, 0.35); }
+
 .neuralguard-install {
   display: flex;
   align-items: center;

--- a/gui/src/App.css
+++ b/gui/src/App.css
@@ -4524,6 +4524,100 @@
   font-size: 0.75rem;
   color: var(--text-muted, #888);
 }
+
+.neuralguard-install {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  margin-bottom: 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(251, 146, 60, 0.4);
+  background: rgba(251, 146, 60, 0.08);
+}
+.neuralguard-install.installed {
+  border-color: rgba(125, 211, 252, 0.4);
+  background: rgba(125, 211, 252, 0.07);
+}
+.neuralguard-install-title { font-weight: 600; color: #e2e8f0; }
+.neuralguard-install-sub { font-size: 0.85rem; color: var(--text-muted, #aaa); margin-top: 0.2rem; }
+
+.prompt-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(2px);
+}
+.prompt-modal {
+  background: #0e0e0e;
+  border: 1px solid rgba(239, 68, 68, 0.5);
+  border-radius: 0.5rem;
+  width: min(640px, 95vw);
+  max-height: 85vh;
+  overflow: auto;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(239, 68, 68, 0.2);
+}
+.prompt-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid #2a2a2a;
+}
+.prompt-modal-title { font-weight: 700; color: #ef4444; }
+.prompt-modal-pid { font-size: 0.8rem; color: var(--text-muted, #888); font-family: monospace; }
+.prompt-modal-body { padding: 1rem; }
+.prompt-modal-tool {
+  font-family: monospace;
+  font-size: 0.85rem;
+  color: #fb923c;
+  margin-bottom: 0.5rem;
+}
+.prompt-modal-cmd {
+  font-family: monospace;
+  font-size: 0.85rem;
+  color: #cbd5e1;
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid #2a2a2a;
+  border-radius: 0.35rem;
+  padding: 0.6rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+  margin-bottom: 0.75rem;
+  max-height: 200px;
+  overflow: auto;
+}
+.prompt-modal-rules {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.prompt-rule {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.3rem;
+  font-size: 0.8rem;
+  background: rgba(255, 255, 255, 0.03);
+}
+.prompt-rule-match {
+  font-family: monospace;
+  color: var(--text-muted, #888);
+  margin-left: auto;
+}
+.prompt-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding: 0.85rem 1rem;
+  border-top: 1px solid #2a2a2a;
+}
 .agent-elapsed { color: var(--text-muted, #888); font-size: 0.85em; min-width: 5em; }
 .agent-last-action {
   color: var(--text-muted, #aaa);

--- a/gui/src/App.css
+++ b/gui/src/App.css
@@ -4548,7 +4548,21 @@
   gap: 0.75rem;
   font-size: 0.75rem;
   color: var(--text-muted, #888);
+  flex-wrap: wrap;
 }
+.security-rule-id { font-family: monospace; }
+.security-explain {
+  font-size: 0.82rem;
+  line-height: 1.4;
+  color: #cbd5e1;
+  background: rgba(255, 255, 255, 0.02);
+  border-left: 2px solid rgba(255, 255, 255, 0.08);
+  padding: 0.5rem 0.7rem;
+  margin: 0.4rem 0 0.4rem 0;
+  border-radius: 0 0.25rem 0.25rem 0;
+}
+.security-explain strong { color: #e2e8f0; }
+.security-explain > div + div { margin-top: 0.25rem; }
 
 .neuralguard-install {
   display: flex;

--- a/gui/src/App.css
+++ b/gui/src/App.css
@@ -4416,6 +4416,31 @@
   border: 1px solid transparent;
   line-height: 1;
 }
+.agent-risk-events {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-top: 0.25rem;
+}
+.agent-risk-event {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 0.3rem;
+  background: rgba(255, 255, 255, 0.03);
+  font-size: 0.78rem;
+}
+.agent-risk-event-rule { font-weight: 600; color: #e2e8f0; }
+.agent-risk-event-match {
+  font-family: monospace;
+  color: var(--text-muted, #888);
+  margin-left: auto;
+  max-width: 60%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .risk-info     { color: #94a3b8; border-color: #94a3b840; }
 .risk-low      { color: #86efac; border-color: #86efac40; background: rgba(134, 239, 172, 0.08); }
 .risk-medium   { color: #fbbf24; border-color: #fbbf2440; background: rgba(251, 191, 36, 0.10); }

--- a/gui/src/App.css
+++ b/gui/src/App.css
@@ -4408,6 +4408,122 @@
 .kind-opencode { color: #7dd3fc; border-color: #7dd3fc40; }
 .kind-kimi     { color: #c4b5fd; border-color: #c4b5fd40; }
 .kind-codex    { color: #86efac; border-color: #86efac40; }
+
+.agent-risk {
+  font-size: 0.95em;
+  padding: 0.05rem 0.35rem;
+  border-radius: 0.25rem;
+  border: 1px solid transparent;
+  line-height: 1;
+}
+.risk-info     { color: #94a3b8; border-color: #94a3b840; }
+.risk-low      { color: #86efac; border-color: #86efac40; background: rgba(134, 239, 172, 0.08); }
+.risk-medium   { color: #fbbf24; border-color: #fbbf2440; background: rgba(251, 191, 36, 0.10); }
+.risk-high     { color: #fb923c; border-color: #fb923c50; background: rgba(251, 146, 60, 0.12); }
+.risk-critical { color: #ef4444; border-color: #ef444460; background: rgba(239, 68, 68, 0.15); font-weight: 700; }
+
+.security-section { padding: 1rem 1.25rem; }
+.security-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 1rem;
+  gap: 1rem;
+}
+.security-header h2 { margin: 0; font-size: 1.25rem; }
+.security-subhead { color: var(--text-muted, #888); font-size: 0.85rem; margin-top: 0.25rem; }
+.security-actions { display: flex; gap: 0.5rem; flex-shrink: 0; }
+
+.security-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+.security-stat {
+  padding: 0.85rem 1rem;
+  border-radius: 0.5rem;
+  background: var(--surface-2, #161616);
+  border: 1px solid var(--border, #2a2a2a);
+}
+.security-stat.critical { border-color: rgba(239, 68, 68, 0.35); }
+.security-stat.high     { border-color: rgba(251, 146, 60, 0.35); }
+.security-stat.medium   { border-color: rgba(251, 191, 36, 0.35); }
+.security-stat.low      { border-color: rgba(134, 239, 172, 0.30); }
+.security-stat-value { font-size: 1.65rem; font-weight: 700; color: #e2e8f0; }
+.security-stat.critical .security-stat-value { color: #ef4444; }
+.security-stat.high     .security-stat-value { color: #fb923c; }
+.security-stat.medium   .security-stat-value { color: #fbbf24; }
+.security-stat.low      .security-stat-value { color: #86efac; }
+.security-stat-label { font-size: 0.75rem; color: var(--text-muted, #888); text-transform: uppercase; letter-spacing: 0.05em; }
+
+.security-toolbar {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.security-feed {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.security-empty {
+  padding: 2.5rem 1rem;
+  text-align: center;
+  color: var(--text-muted, #888);
+  border: 1px dashed var(--border, #2a2a2a);
+  border-radius: 0.5rem;
+}
+.security-row {
+  padding: 0.75rem 1rem;
+  border-radius: 0.4rem;
+  background: var(--surface-2, #141414);
+  border-left: 3px solid var(--border, #2a2a2a);
+}
+.security-row.severity-critical { border-left-color: #ef4444; background: rgba(239, 68, 68, 0.06); }
+.security-row.severity-high     { border-left-color: #fb923c; }
+.security-row.severity-medium   { border-left-color: #fbbf24; }
+.security-row.severity-low      { border-left-color: #86efac; }
+
+.security-row-head {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 0.35rem;
+}
+.severity-pill {
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.25rem;
+  letter-spacing: 0.05em;
+}
+.sev-critical { background: rgba(239, 68, 68, 0.2); color: #ef4444; }
+.sev-high     { background: rgba(251, 146, 60, 0.2); color: #fb923c; }
+.sev-medium   { background: rgba(251, 191, 36, 0.2); color: #fbbf24; }
+.sev-low      { background: rgba(134, 239, 172, 0.2); color: #86efac; }
+.sev-info     { background: rgba(148, 163, 184, 0.2); color: #94a3b8; }
+.security-rule { font-weight: 600; color: #e2e8f0; }
+.security-tool { font-family: monospace; font-size: 0.85em; color: var(--text-muted, #aaa); }
+.security-ts   { margin-left: auto; color: var(--text-muted, #888); font-size: 0.8rem; }
+.security-matched {
+  font-family: monospace;
+  font-size: 0.85rem;
+  color: #cbd5e1;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 0.35rem 0.5rem;
+  border-radius: 0.25rem;
+  word-break: break-all;
+  margin-bottom: 0.4rem;
+}
+.security-meta {
+  display: flex;
+  gap: 0.75rem;
+  font-size: 0.75rem;
+  color: var(--text-muted, #888);
+}
 .agent-elapsed { color: var(--text-muted, #888); font-size: 0.85em; min-width: 5em; }
 .agent-last-action {
   color: var(--text-muted, #aaa);

--- a/gui/src/App.css
+++ b/gui/src/App.css
@@ -4448,6 +4448,27 @@
   font-style: italic;
   max-width: 100%;
 }
+
+.agent-tail {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.15rem;
+  margin-left: auto;
+  min-width: 0;
+  max-width: 35%;
+  flex-shrink: 1;
+}
+.agent-activity {
+  font-size: 0.85rem;
+  color: #e2e8f0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+.agent-tail .agent-cwd { font-size: 0.72em; }
+.agent-tail .agent-elapsed { font-size: 0.72em; min-width: 0; }
 .agent-kind {
   font-size: 0.7em;
   text-transform: uppercase;

--- a/gui/src/App.css
+++ b/gui/src/App.css
@@ -4379,8 +4379,8 @@
   min-width: 0;
   margin-left: auto;
 }
-.agent-summary .agent-project {
-  min-width: 7rem;
+.agent-summary .agent-name {
+  min-width: 5rem;
 }
 .agent-summary:hover { background: var(--surface-2, #1a1a1a); }
 .agent-status-dot {
@@ -4390,7 +4390,16 @@
 .status-active { background: #4ade80; box-shadow: 0 0 6px #4ade80aa; }
 .status-idle   { background: #fbbf24; }
 .status-stale  { background: #555; }
-.agent-project { font-weight: 600; }
+.agent-name {
+  font-weight: 700;
+  color: #e2e8f0;
+  font-size: 0.95rem;
+}
+.agent-project {
+  font-weight: 500;
+  color: var(--text-muted, #aaa);
+  font-size: 0.85em;
+}
 .agent-cwd     { color: var(--text-muted, #888); font-family: monospace; font-size: 0.8em; }
 .agent-branch  { color: var(--text-muted, #888); font-family: monospace; font-size: 0.85em; }
 .agent-avatar {

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -97,148 +97,192 @@ interface SecurityEvent {
   actor: string;
 }
 
-const RULE_INFO: Record<string, { title: string; what: string; why: string }> = {
+interface RuleInfo {
+  title: string;
+  what: string;
+  why: string;
+  recommend: string;
+}
+
+const RULE_INFO: Record<string, RuleInfo> = {
   "destructive-rm": {
     title: "Recursive delete of a critical path",
     what: "rm -rf was pointed at /, ~ (home), $HOME, or used --no-preserve-root.",
     why: "These wipe everything inside the target. A single hijacked or buggy command here destroys your work and may take the whole user account or system with it.",
+    recommend: "If it ran: stop the agent now and restore from backup or `git restore`. If blocked: leave it blocked, then add a CLAUDE.md note for this repo telling the agent never to use rm -rf on home/system paths.",
   },
   "dd-block-device": {
     title: "Raw write to a disk device",
     what: "dd was given a block device (sd*, nvme*, hd*) as its output.",
     why: "Writing to /dev/sda et al overwrites the partition table and filesystem. Used to wipe drives or install rootkits.",
+    recommend: "If it ran: power off and boot from rescue media before continuing — the live disk may be corrupt. If blocked: keep it blocked; legitimate disk imaging belongs in a manual terminal, not an agent.",
   },
   "pipe-to-shell": {
     title: "Run remote script unsupervised",
     what: "A download (curl/wget/fetch) was piped straight into sh/bash.",
     why: "Whatever the URL serves runs immediately as you. If the server is hostile or compromised, the agent has just executed arbitrary code without anyone reading it first.",
+    recommend: "Treat as compromise until proven otherwise: audit recent file changes (`find ~ -mmin -60 -type f`), check ~/.cache and /tmp for downloaded payloads, review crontab + systemd --user units, rotate any credential the host could have read.",
   },
   "base64-exec": {
     title: "Decode-and-execute payload",
     what: "base64 -d was piped into a shell or interpreter.",
     why: "Encoded payloads piped to sh/python/node are the standard pattern for hiding malicious code from review tools and scanners.",
+    recommend: "Capture the original command from the event detail, decode it manually (`echo '<payload>' | base64 -d | less`) before doing anything else; treat the host as compromised if you cannot identify the source.",
   },
   "sudo": {
     title: "Privilege escalation",
     what: "Command was prefixed with sudo to run as root.",
     why: "Once an agent runs as root there is no permission boundary left. A mistake or a prompt-injection from a fetched page now has full system rights.",
+    recommend: "Review what changed: `sudo apt history` (or `journalctl _UID=0 --since=today`). Consider switching policy.yaml `mode` to `prompt` for sudo so each call surfaces a confirm dialog.",
   },
   "setuid-bit": {
     title: "Setuid bit set",
     what: "chmod +s was applied to a file.",
     why: "A setuid binary runs as its owner regardless of who launches it — the standard local-privilege-escalation backdoor.",
+    recommend: "Find new setuid binaries with `find / -perm -4000 -newer /etc/hostname 2>/dev/null` and remove anything you don't recognise.",
   },
   "setcap": {
     title: "Linux capability granted",
     what: "setcap was used to grant a binary kernel capabilities.",
     why: "Capabilities like cap_net_admin or cap_dac_read_search hand a regular binary near-root powers without flipping the setuid bit.",
+    recommend: "Audit caps with `getcap -r / 2>/dev/null` and revoke unexpected entries via `sudo setcap -r <path>`.",
   },
   "ssh-key-access": {
     title: "Reading or moving SSH keys",
     what: "An SSH key file (~/.ssh/id_*, authorized_keys, known_hosts) was about to be read or copied.",
     why: "SSH private keys unlock every server you access. Reading them is the first step toward exfiltrating them.",
+    recommend: "Rotate keys: `ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519` and update authorized_keys on every remote. Consider passphrase + ssh-agent so on-disk keys are encrypted.",
   },
   "ssh-key-write": {
     title: "Writing to your SSH key folder",
     what: "A write was directed at ~/.ssh/id_* or authorized_keys.",
     why: "Adding a key to authorized_keys is how attackers persist remote access. Overwriting your private key locks you out and can replace it with one they control.",
+    recommend: "Open ~/.ssh/authorized_keys, remove any line you don't recognise, then rotate the local key. If a private key was overwritten, restore from backup before doing anything else over SSH.",
   },
   "gpg-access": {
     title: "Touching your GPG keyring",
     what: "An action targeted ~/.gnupg/.",
     why: "GPG keys sign your commits and decrypt secrets. Exfiltrating them lets others impersonate you or read encrypted data.",
+    recommend: "Run `gpg --list-secret-keys` and verify the listed key IDs match yours. If unsure, revoke and re-issue (`gpg --gen-revoke`) and re-encrypt anything sensitive.",
   },
   "aws-credentials": {
     title: "Reading AWS credentials",
     what: "An AWS credentials file was about to be opened.",
     why: "Cloud keys grant full account access — usually with a billing limit measured in tens of thousands of dollars.",
+    recommend: "Treat the access key as leaked: rotate immediately in IAM, review CloudTrail for unfamiliar API calls in the last 24h, and switch to short-lived SSO/STS tokens going forward.",
   },
   "credentials-read": {
     title: "Reading a credentials file",
     what: "A read was aimed at .aws/credentials or ~/.gnupg/.",
     why: "Same risk as above — these files contain long-lived secrets that unlock other systems.",
+    recommend: "Rotate the credential and audit recent provider activity (CloudTrail / GCP audit logs / etc).",
   },
   "secret-exfil": {
     title: "Network call referencing secrets",
     what: "curl/wget/scp/rsync was used and the command mentioned ssh, aws, gnupg, credentials, secret, token, or api_key.",
     why: "A network tool combined with a secret-shaped string is the canonical exfiltration pattern — one HTTP request and the secret is gone.",
+    recommend: "Treat any secret named in the command as compromised: rotate it (API key, token, AWS access key), review provider audit logs since the event timestamp, and flip the egress monitor on so future calls surface the destination host.",
   },
   "shell-rc-tamper": {
     title: "Modifying your shell startup file",
     what: "A redirection wrote to .bashrc / .zshrc / .profile and friends.",
     why: "Shell rc files run on every new terminal. Anything appended here persists invisibly across reboots and is the most common AI-agent persistence trick.",
+    recommend: "Diff the file against your dotfiles repo or a backup (`git diff -- ~/.bashrc`). Remove anything you didn't add; open a fresh terminal to verify.",
   },
   "shell-rc-write": {
     title: "Writing your shell startup file",
     what: "Write tool targeted .bashrc / .zshrc / .profile.",
     why: "Same as above — anything here runs every time you open a terminal.",
+    recommend: "Same: diff against backup/dotfiles, strip surprises, open a new shell.",
   },
   "env-file-write": {
     title: "Writing a .env file",
     what: "A .env file was about to be written.",
     why: "These usually hold API keys and DB passwords. Overwriting them is silent and easy to miss; injecting a new value lets a future read steal credentials.",
+    recommend: "Diff the file against version control or a backup; if a known-good version is hard to recover, rotate every secret it held before re-running the app.",
   },
   "system-config-write": {
     title: "Writing into /etc/",
     what: "A write targeted /etc/.",
     why: "/etc holds system configuration. Most edits there require sudo and persist for every user — high-impact, high-permanence, often invisible.",
+    recommend: "Inspect the file (`sudo less <path>`), revert to package default if available (`sudo dpkg --force-confmiss --force-confnew --reinstall <pkg>` for Debian/Ubuntu), or restore from backup.",
   },
   "mass-kill": {
     title: "Aggressive process kill",
     what: "pkill or killall was used with -9 (SIGKILL).",
     why: "SIGKILL skips clean shutdown. Mass-killing system services or dev tools causes data loss and is occasionally used to disable security agents.",
+    recommend: "Check what was killed (`journalctl -p warning --since '5 min ago'`) and restart anything important — DB servers, your editor, security agents.",
   },
   "git-remote-rewrite": {
     title: "Repointing a git remote",
     what: "git remote set-url or add was used to change the upstream URL.",
     why: "Silently moves your pushes to a different repo. Used to capture credentials or exfiltrate code on the next push.",
+    recommend: "Run `git remote -v` in the affected repo and reset any remote that doesn't match what you expect (`git remote set-url <name> <correct-url>`). Rotate any push token used since.",
   },
   "history-tamper": {
     title: "Clearing shell history",
     what: "history -c was invoked.",
     why: "Wipes the audit trail of what just happened in the shell. Almost never has a legitimate developer reason.",
+    recommend: "Cross-reference against the agent's jsonl log (every tool call is recorded there) and review recent file changes via `git status` / `find ~ -mmin -120`.",
   },
   "history-redir-tamper": {
     title: "Truncating shell history file",
     what: "Redirection truncated .bash_history or .zsh_history.",
     why: "Same audit-trail concern as history -c — covers tracks of prior commands.",
+    recommend: "Same — fall back to the agent's jsonl session log; that record cannot be edited by a tool call.",
   },
   "fetch-ip-literal": {
     title: "Fetching a raw IP",
     what: "WebFetch URL used a numeric IP instead of a hostname.",
     why: "Bare-IP URLs bypass DNS and TLS hostname checks; common in shellcode/loader hosting.",
+    recommend: "Look up the IP (`whois <ip>` or any reputation site) before treating any data fetched as trustworthy. Reject the call if the host doesn't have a clear legitimate name.",
   },
   "fetch-onion": {
     title: "Fetching from a .onion address",
     what: "URL points at a Tor hidden service.",
     why: "Almost always indicates malware C2 or tooling distribution that wants to be hard to attribute.",
+    recommend: "Block the call. There is no benign reason an AI coding agent should fetch from .onion in normal development.",
   },
   "egress-unknown-host": {
     title: "Outbound connection to unrecognised host",
     what: "Agent process opened a TCP connection to an IP not on the dev/AI allowlist.",
     why: "Unexpected egress is how data leaves your machine. Worth a glance even if benign — it tells you who your agent is talking to.",
+    recommend: "Reverse-lookup the IP (`dig -x <ip>` or whois). If legitimate (e.g. CDN edge for an AI provider), add the hostname to the egress allowlist; if not, suspect a leak and rotate touched credentials.",
   },
   "injection-ignore-previous": {
     title: "Likely prompt injection",
     what: "Tool result contained 'ignore previous instructions' or a close variant.",
     why: "Classic jailbreak phrasing planted in fetched content. Successful injection makes the agent do the attacker's bidding using your permissions.",
+    recommend: "Stop the agent before it acts on the fetched content. Re-fetch from a trusted source or paste the relevant info manually after sanitising it.",
   },
   "injection-roleplay": {
     title: "Likely prompt injection (roleplay)",
     what: "Tool result tried to push the model into a 'jailbreak' / 'developer mode' / 'DAN' persona.",
     why: "Same risk as above — these phrasings are designed to switch the model out of its safety posture.",
+    recommend: "Same: stop, sanitise, retry without the contaminated content.",
   },
   "injection-system-marker": {
     title: "Possible fake system message",
     what: "Tool result contained [SYSTEM], <system>, or ### system ### markers.",
     why: "External text impersonating a system role is how injectors smuggle privileged-looking instructions into the conversation.",
+    recommend: "Strip the markers before letting the agent continue; or re-fetch from a source that doesn't include them.",
   },
   "injection-hidden-unicode": {
     title: "Hidden Unicode in tool result",
     what: "Tool result contained zero-width or Unicode tag characters.",
     why: "Invisible characters can encode instructions the model reads but you don't. Often used to slip injection past human review.",
+    recommend: "Pipe the source through `iconv -f utf-8 -t ascii//TRANSLIT` or a unicode-strip tool before re-feeding to the agent.",
   },
 };
+
+function eventOutcome(decision: string, actor: string): { label: string; tone: "blocked" | "ran-warn" | "ran-info" | "pending" } {
+  if (decision === "denied") return { label: "Blocked before running", tone: "blocked" };
+  if (decision === "allowed") return { label: actor === "user" ? "Allowed by you — ran" : "Allowed — ran", tone: "ran-warn" };
+  if (decision === "prompted") return { label: "Awaiting your decision", tone: "pending" };
+  if (actor === "egress-monitor") return { label: "Connection observed", tone: "ran-info" };
+  if (actor === "rule-engine") return { label: "Already ran (caught after the fact)", tone: "ran-warn" };
+  return { label: "Observed", tone: "ran-info" };
+}
 
 interface PendingPrompt {
   id: string;
@@ -1839,6 +1883,7 @@ function App() {
           ) : (
             sortedDesc.map((e) => {
               const info = RULE_INFO[e.rule];
+              const outcome = eventOutcome(e.decision, e.actor);
               return (
                 <div key={e.id} className={`security-row severity-${e.severity}`}>
                   <div className="security-row-head">
@@ -1848,6 +1893,9 @@ function App() {
                     <span className="security-rule">
                       {info ? info.title : e.rule}
                     </span>
+                    <span className={`outcome-pill outcome-${outcome.tone}`}>
+                      {outcome.label}
+                    </span>
                     <span className="security-tool">{e.tool}</span>
                     <span className="security-ts">{formatTs(e.ts)}</span>
                   </div>
@@ -1856,6 +1904,7 @@ function App() {
                     <div className="security-explain">
                       <div><strong>What:</strong> {info.what}</div>
                       <div><strong>Why risky:</strong> {info.why}</div>
+                      <div><strong>What to do:</strong> {info.recommend}</div>
                     </div>
                   )}
                   <div className="security-meta">

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -82,6 +82,8 @@ interface AgentInfo {
   role: string;
   role_icon: string;
   topic: string | null;
+  current_task: string | null;
+  activity: string | null;
   name: string;
 }
 
@@ -1633,19 +1635,6 @@ function App() {
       return parts.slice(-3).join("/");
     }
 
-    function agentHeadline(a: AgentInfo): string {
-      const action = (a.last_action ?? "").trim();
-      const msg = (a.last_user_msg ?? "").trim();
-      const noisy = /^Bash:\s*[\{\(]|^Bash:\s*\w+\s*\(\)\s*\{|;|\b(kill|sleep|cd|ls|cat|grep|sudo|tail|head)\b/;
-      const looksNoisy =
-        action.startsWith("Bash: ") &&
-        (noisy.test(action) || /[{}();$]/.test(action));
-      if (looksNoisy && msg) {
-        return msg.length > 80 ? msg.slice(0, 80) + "…" : msg;
-      }
-      return action || msg || "—";
-    }
-
     return (
       <div className="agents-section">
         <div className="agents-header">
@@ -1694,18 +1683,25 @@ function App() {
                         )}
                         {a.branch && <span className="agent-branch">{a.branch}</span>}
                       </span>
-                      {a.topic && (
-                        <span className="agent-topic" title={a.topic}>
-                          {a.topic}
+                      {(a.current_task || a.topic) && (
+                        <span
+                          className="agent-topic"
+                          title={a.topic || a.current_task || undefined}
+                        >
+                          {a.current_task || a.topic}
                         </span>
                       )}
                     </span>
-                    <span className="agent-cwd" title={a.cwd}>
-                      {shortenCwd(a.cwd)}
-                    </span>
-                    <span className="agent-elapsed">{elapsedSince(a.started_at)}</span>
-                    <span className="agent-last-action">
-                      {agentHeadline(a)}
+                    <span className="agent-tail">
+                      {a.activity && (
+                        <span className="agent-activity" title={a.activity}>
+                          {a.activity}
+                        </span>
+                      )}
+                      <span className="agent-cwd" title={a.cwd}>
+                        {shortenCwd(a.cwd)}
+                      </span>
+                      <span className="agent-elapsed">{elapsedSince(a.started_at)}</span>
                     </span>
                   </button>
                   {expanded && (

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -256,6 +256,7 @@ function App() {
     gate_script: string;
   } | null>(null);
   const [pendingPrompts, setPendingPrompts] = useState<PendingPrompt[]>([]);
+  const [egressEnabled, setEgressEnabled] = useState(false);
   const [hooks, setHooks] = useState<HookConfig[]>([]);
   const [plugins, setPlugins] = useState<PluginInfo[]>([]);
   const [editingAgent, setEditingAgent] = useState<AgentConfig | null>(null);
@@ -481,6 +482,23 @@ function App() {
       setNeuralguardStatus(s);
     } catch (e) {
       // Ignore
+    }
+    try {
+      const enabled = await invoke<boolean>("get_egress_enabled");
+      setEgressEnabled(enabled);
+    } catch (e) {
+      // Ignore
+    }
+  }
+
+  async function handleToggleEgress() {
+    const next = !egressEnabled;
+    setEgressEnabled(next);
+    try {
+      await invoke("set_egress_enabled", { enabled: next });
+    } catch (e) {
+      setEgressEnabled(!next);
+      setError(String(e));
     }
   }
 
@@ -1603,6 +1621,28 @@ function App() {
                 Install hooks
               </button>
             )}
+          </div>
+        </div>
+
+        <div className={`neuralguard-install ${egressEnabled ? "installed" : ""}`}>
+          <div className="neuralguard-install-text">
+            <div className="neuralguard-install-title">
+              {egressEnabled ? "Egress monitor on" : "Egress monitor off"}
+            </div>
+            <div className="neuralguard-install-sub">
+              Polls established TCP connections from claude/opencode/kimi/codex
+              processes every 30s and flags traffic to hosts not on the
+              allowlist (api.anthropic.com, github.com, registry.npmjs.org,
+              pypi.org, etc.).
+            </div>
+          </div>
+          <div className="neuralguard-install-actions">
+            <button
+              className={`claude-btn ${egressEnabled ? "danger" : "primary"}`}
+              onClick={handleToggleEgress}
+            >
+              {egressEnabled ? "Disable" : "Enable"}
+            </button>
           </div>
         </div>
 

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -97,6 +97,149 @@ interface SecurityEvent {
   actor: string;
 }
 
+const RULE_INFO: Record<string, { title: string; what: string; why: string }> = {
+  "destructive-rm": {
+    title: "Recursive delete of a critical path",
+    what: "rm -rf was pointed at /, ~ (home), $HOME, or used --no-preserve-root.",
+    why: "These wipe everything inside the target. A single hijacked or buggy command here destroys your work and may take the whole user account or system with it.",
+  },
+  "dd-block-device": {
+    title: "Raw write to a disk device",
+    what: "dd was given a block device (sd*, nvme*, hd*) as its output.",
+    why: "Writing to /dev/sda et al overwrites the partition table and filesystem. Used to wipe drives or install rootkits.",
+  },
+  "pipe-to-shell": {
+    title: "Run remote script unsupervised",
+    what: "A download (curl/wget/fetch) was piped straight into sh/bash.",
+    why: "Whatever the URL serves runs immediately as you. If the server is hostile or compromised, the agent has just executed arbitrary code without anyone reading it first.",
+  },
+  "base64-exec": {
+    title: "Decode-and-execute payload",
+    what: "base64 -d was piped into a shell or interpreter.",
+    why: "Encoded payloads piped to sh/python/node are the standard pattern for hiding malicious code from review tools and scanners.",
+  },
+  "sudo": {
+    title: "Privilege escalation",
+    what: "Command was prefixed with sudo to run as root.",
+    why: "Once an agent runs as root there is no permission boundary left. A mistake or a prompt-injection from a fetched page now has full system rights.",
+  },
+  "setuid-bit": {
+    title: "Setuid bit set",
+    what: "chmod +s was applied to a file.",
+    why: "A setuid binary runs as its owner regardless of who launches it — the standard local-privilege-escalation backdoor.",
+  },
+  "setcap": {
+    title: "Linux capability granted",
+    what: "setcap was used to grant a binary kernel capabilities.",
+    why: "Capabilities like cap_net_admin or cap_dac_read_search hand a regular binary near-root powers without flipping the setuid bit.",
+  },
+  "ssh-key-access": {
+    title: "Reading or moving SSH keys",
+    what: "An SSH key file (~/.ssh/id_*, authorized_keys, known_hosts) was about to be read or copied.",
+    why: "SSH private keys unlock every server you access. Reading them is the first step toward exfiltrating them.",
+  },
+  "ssh-key-write": {
+    title: "Writing to your SSH key folder",
+    what: "A write was directed at ~/.ssh/id_* or authorized_keys.",
+    why: "Adding a key to authorized_keys is how attackers persist remote access. Overwriting your private key locks you out and can replace it with one they control.",
+  },
+  "gpg-access": {
+    title: "Touching your GPG keyring",
+    what: "An action targeted ~/.gnupg/.",
+    why: "GPG keys sign your commits and decrypt secrets. Exfiltrating them lets others impersonate you or read encrypted data.",
+  },
+  "aws-credentials": {
+    title: "Reading AWS credentials",
+    what: "An AWS credentials file was about to be opened.",
+    why: "Cloud keys grant full account access — usually with a billing limit measured in tens of thousands of dollars.",
+  },
+  "credentials-read": {
+    title: "Reading a credentials file",
+    what: "A read was aimed at .aws/credentials or ~/.gnupg/.",
+    why: "Same risk as above — these files contain long-lived secrets that unlock other systems.",
+  },
+  "secret-exfil": {
+    title: "Network call referencing secrets",
+    what: "curl/wget/scp/rsync was used and the command mentioned ssh, aws, gnupg, credentials, secret, token, or api_key.",
+    why: "A network tool combined with a secret-shaped string is the canonical exfiltration pattern — one HTTP request and the secret is gone.",
+  },
+  "shell-rc-tamper": {
+    title: "Modifying your shell startup file",
+    what: "A redirection wrote to .bashrc / .zshrc / .profile and friends.",
+    why: "Shell rc files run on every new terminal. Anything appended here persists invisibly across reboots and is the most common AI-agent persistence trick.",
+  },
+  "shell-rc-write": {
+    title: "Writing your shell startup file",
+    what: "Write tool targeted .bashrc / .zshrc / .profile.",
+    why: "Same as above — anything here runs every time you open a terminal.",
+  },
+  "env-file-write": {
+    title: "Writing a .env file",
+    what: "A .env file was about to be written.",
+    why: "These usually hold API keys and DB passwords. Overwriting them is silent and easy to miss; injecting a new value lets a future read steal credentials.",
+  },
+  "system-config-write": {
+    title: "Writing into /etc/",
+    what: "A write targeted /etc/.",
+    why: "/etc holds system configuration. Most edits there require sudo and persist for every user — high-impact, high-permanence, often invisible.",
+  },
+  "mass-kill": {
+    title: "Aggressive process kill",
+    what: "pkill or killall was used with -9 (SIGKILL).",
+    why: "SIGKILL skips clean shutdown. Mass-killing system services or dev tools causes data loss and is occasionally used to disable security agents.",
+  },
+  "git-remote-rewrite": {
+    title: "Repointing a git remote",
+    what: "git remote set-url or add was used to change the upstream URL.",
+    why: "Silently moves your pushes to a different repo. Used to capture credentials or exfiltrate code on the next push.",
+  },
+  "history-tamper": {
+    title: "Clearing shell history",
+    what: "history -c was invoked.",
+    why: "Wipes the audit trail of what just happened in the shell. Almost never has a legitimate developer reason.",
+  },
+  "history-redir-tamper": {
+    title: "Truncating shell history file",
+    what: "Redirection truncated .bash_history or .zsh_history.",
+    why: "Same audit-trail concern as history -c — covers tracks of prior commands.",
+  },
+  "fetch-ip-literal": {
+    title: "Fetching a raw IP",
+    what: "WebFetch URL used a numeric IP instead of a hostname.",
+    why: "Bare-IP URLs bypass DNS and TLS hostname checks; common in shellcode/loader hosting.",
+  },
+  "fetch-onion": {
+    title: "Fetching from a .onion address",
+    what: "URL points at a Tor hidden service.",
+    why: "Almost always indicates malware C2 or tooling distribution that wants to be hard to attribute.",
+  },
+  "egress-unknown-host": {
+    title: "Outbound connection to unrecognised host",
+    what: "Agent process opened a TCP connection to an IP not on the dev/AI allowlist.",
+    why: "Unexpected egress is how data leaves your machine. Worth a glance even if benign — it tells you who your agent is talking to.",
+  },
+  "injection-ignore-previous": {
+    title: "Likely prompt injection",
+    what: "Tool result contained 'ignore previous instructions' or a close variant.",
+    why: "Classic jailbreak phrasing planted in fetched content. Successful injection makes the agent do the attacker's bidding using your permissions.",
+  },
+  "injection-roleplay": {
+    title: "Likely prompt injection (roleplay)",
+    what: "Tool result tried to push the model into a 'jailbreak' / 'developer mode' / 'DAN' persona.",
+    why: "Same risk as above — these phrasings are designed to switch the model out of its safety posture.",
+  },
+  "injection-system-marker": {
+    title: "Possible fake system message",
+    what: "Tool result contained [SYSTEM], <system>, or ### system ### markers.",
+    why: "External text impersonating a system role is how injectors smuggle privileged-looking instructions into the conversation.",
+  },
+  "injection-hidden-unicode": {
+    title: "Hidden Unicode in tool result",
+    what: "Tool result contained zero-width or Unicode tag characters.",
+    why: "Invisible characters can encode instructions the model reads but you don't. Often used to slip injection past human review.",
+  },
+};
+
 interface PendingPrompt {
   id: string;
   ts: string;
@@ -512,7 +655,7 @@ function App() {
   }
 
   async function handleUninstallHooks() {
-    if (!confirm("Remove NeuralGuard from Claude Code hooks?")) return;
+    if (!confirm("Remove AI Security hooks from Claude Code?")) return;
     try {
       await invoke<string>("uninstall_neuralguard_hooks");
       loadNeuralguardStatus();
@@ -1525,15 +1668,23 @@ function App() {
                             Security events ({a.risk_events.length})
                           </div>
                           <div className="agent-risk-events">
-                            {a.risk_events.slice(-10).reverse().map((e) => (
-                              <div key={e.id} className={`agent-risk-event sev-${e.severity}`}>
-                                <span className={`severity-pill sev-${e.severity}`}>
-                                  {e.severity.toUpperCase()}
-                                </span>
-                                <span className="agent-risk-event-rule">{e.rule}</span>
-                                <span className="agent-risk-event-match">{e.matched}</span>
-                              </div>
-                            ))}
+                            {a.risk_events.slice(-10).reverse().map((e) => {
+                              const info = RULE_INFO[e.rule];
+                              return (
+                                <div key={e.id} className={`agent-risk-event sev-${e.severity}`}>
+                                  <span className={`severity-pill sev-${e.severity}`}>
+                                    {e.severity.toUpperCase()}
+                                  </span>
+                                  <span
+                                    className="agent-risk-event-rule"
+                                    title={info ? info.why : e.rule}
+                                  >
+                                    {info ? info.title : e.rule}
+                                  </span>
+                                  <span className="agent-risk-event-match">{e.matched}</span>
+                                </div>
+                              );
+                            })}
                           </div>
                         </div>
                       )}
@@ -1585,9 +1736,9 @@ function App() {
       <div className="security-section">
         <div className="security-header">
           <div>
-            <h2>NeuralGuard Security</h2>
+            <h2>AI Security</h2>
             <div className="security-subhead">
-              Local AI agent runtime monitor — rules-based event feed
+              Local AI agent runtime monitor — flags risky actions before they happen
             </div>
           </div>
           <div className="security-actions">
@@ -1603,12 +1754,12 @@ function App() {
         <div className={`neuralguard-install ${installed ? "installed" : ""}`}>
           <div className="neuralguard-install-text">
             <div className="neuralguard-install-title">
-              {installed ? "NeuralGuard hooks active" : "NeuralGuard hooks not installed"}
+              {installed ? "AI Security hooks active" : "AI Security hooks not installed"}
             </div>
             <div className="neuralguard-install-sub">
               {installed
                 ? "Claude Code calls go through the gate. Critical rules deny by default; edit policy.yaml to add prompt/strict modes."
-                : "Install hooks to make Claude Code consult NeuralGuard before each tool call. Until then this view is observe-only over jsonl logs."}
+                : "Install hooks so Claude Code asks AI Security before each tool call. Until then this view is observe-only over jsonl logs."}
             </div>
           </div>
           <div className="neuralguard-install-actions">
@@ -1686,25 +1837,37 @@ function App() {
               No security events. Run an agent and any flagged tool calls will appear here.
             </div>
           ) : (
-            sortedDesc.map((e) => (
-              <div key={e.id} className={`security-row severity-${e.severity}`}>
-                <div className="security-row-head">
-                  <span className={`severity-pill sev-${e.severity}`}>
-                    {e.severity.toUpperCase()}
-                  </span>
-                  <span className="security-rule">{e.rule}</span>
-                  <span className="security-tool">{e.tool}</span>
-                  <span className="security-ts">{formatTs(e.ts)}</span>
+            sortedDesc.map((e) => {
+              const info = RULE_INFO[e.rule];
+              return (
+                <div key={e.id} className={`security-row severity-${e.severity}`}>
+                  <div className="security-row-head">
+                    <span className={`severity-pill sev-${e.severity}`}>
+                      {e.severity.toUpperCase()}
+                    </span>
+                    <span className="security-rule">
+                      {info ? info.title : e.rule}
+                    </span>
+                    <span className="security-tool">{e.tool}</span>
+                    <span className="security-ts">{formatTs(e.ts)}</span>
+                  </div>
+                  <div className="security-matched">{e.matched}</div>
+                  {info && (
+                    <div className="security-explain">
+                      <div><strong>What:</strong> {info.what}</div>
+                      <div><strong>Why risky:</strong> {info.why}</div>
+                    </div>
+                  )}
+                  <div className="security-meta">
+                    <span className="security-rule-id">rule: {e.rule}</span>
+                    {e.agent_kind && <span>{e.agent_kind}</span>}
+                    {e.agent_pid && <span>pid {e.agent_pid}</span>}
+                    {e.agent_cwd && <span title={e.agent_cwd}>{e.agent_cwd.split("/").slice(-2).join("/")}</span>}
+                    <span>· {e.actor} → {e.decision}</span>
+                  </div>
                 </div>
-                <div className="security-matched">{e.matched}</div>
-                <div className="security-meta">
-                  {e.agent_kind && <span>{e.agent_kind}</span>}
-                  {e.agent_pid && <span>pid {e.agent_pid}</span>}
-                  {e.agent_cwd && <span title={e.agent_cwd}>{e.agent_cwd.split("/").slice(-2).join("/")}</span>}
-                  <span>· {e.actor} → {e.decision}</span>
-                </div>
-              </div>
-            ))
+              );
+            })
           )}
         </div>
       </div>
@@ -3856,20 +4019,23 @@ function App() {
       <div className="prompt-modal-backdrop">
         <div className="prompt-modal">
           <div className="prompt-modal-header">
-            <span className="prompt-modal-title">⛨ NeuralGuard — confirm tool call</span>
+            <span className="prompt-modal-title">⛨ AI Security — confirm tool call</span>
             <span className="prompt-modal-pid">pid {p.agent_pid ?? "?"}</span>
           </div>
           <div className="prompt-modal-body">
             <div className="prompt-modal-tool">{p.tool}</div>
             <pre className="prompt-modal-cmd">{command}</pre>
             <div className="prompt-modal-rules">
-              {p.events.map((ev, i) => (
-                <div key={i} className={`prompt-rule sev-${ev.severity}`}>
-                  <span className={`severity-pill sev-${ev.severity}`}>{ev.severity.toUpperCase()}</span>
-                  <span>{ev.rule}</span>
-                  <span className="prompt-rule-match">{ev.matched}</span>
-                </div>
-              ))}
+              {p.events.map((ev, i) => {
+                const info = RULE_INFO[ev.rule];
+                return (
+                  <div key={i} className={`prompt-rule sev-${ev.severity}`}>
+                    <span className={`severity-pill sev-${ev.severity}`}>{ev.severity.toUpperCase()}</span>
+                    <span title={info ? info.why : ev.rule}>{info ? info.title : ev.rule}</span>
+                    <span className="prompt-rule-match">{ev.matched}</span>
+                  </div>
+                );
+              })}
             </div>
           </div>
           <div className="prompt-modal-footer">

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -77,6 +77,23 @@ interface AgentInfo {
   last_action: string | null;
   session_id: string | null;
   jsonl_path: string | null;
+  risk: "info" | "low" | "medium" | "high" | "critical" | null;
+}
+
+interface SecurityEvent {
+  id: string;
+  ts: string;
+  agent_pid: number | null;
+  agent_kind: string | null;
+  agent_cwd: string | null;
+  session_id: string | null;
+  tool: string;
+  rule: string;
+  severity: "info" | "low" | "medium" | "high" | "critical";
+  matched: string;
+  raw: unknown;
+  decision: string;
+  actor: string;
 }
 
 interface CommandConfig {
@@ -158,7 +175,7 @@ interface GitHubIssuesResponse {
   error: string | null;
 }
 
-type Section = "worktrees" | "knowledge" | "agents" | "voice" | "memory" | "config" | "github";
+type Section = "worktrees" | "knowledge" | "agents" | "security" | "voice" | "memory" | "config" | "github";
 
 interface KnowledgeMeta {
   pinned: string[];
@@ -219,6 +236,8 @@ function App() {
   const [commands, setCommands] = useState<CommandConfig[]>([]);
   const [skills, setSkills] = useState<SkillConfig[]>([]);
   const [voiceMuted, setVoiceMuted] = useState(false);
+  const [securityEvents, setSecurityEvents] = useState<SecurityEvent[]>([]);
+  const [securityFilter, setSecurityFilter] = useState<"all" | "high+">("all");
   const [hooks, setHooks] = useState<HookConfig[]>([]);
   const [plugins, setPlugins] = useState<PluginInfo[]>([]);
   const [editingAgent, setEditingAgent] = useState<AgentConfig | null>(null);
@@ -403,6 +422,42 @@ function App() {
     const id = setInterval(loadVoiceMuted, 5000);
     return () => clearInterval(id);
   }, []);
+
+  // Security events polling
+  useEffect(() => {
+    if (currentSection !== "security") return;
+    loadSecurityEvents();
+    const id = setInterval(loadSecurityEvents, 4000);
+    return () => clearInterval(id);
+  }, [currentSection]);
+
+  async function loadSecurityEvents() {
+    try {
+      const list = await invoke<SecurityEvent[]>("list_security_events", { limit: 200 });
+      setSecurityEvents(list);
+    } catch (e) {
+      // Ignore
+    }
+  }
+
+  async function handleClearSecurityEvents() {
+    if (!confirm("Clear all security events?")) return;
+    try {
+      await invoke("clear_security_events");
+      loadSecurityEvents();
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  async function handleRescanSessions() {
+    try {
+      await invoke("scan_all_sessions");
+      loadSecurityEvents();
+    } catch (e) {
+      setError(String(e));
+    }
+  }
 
   async function loadVoiceMuted() {
     try {
@@ -1338,6 +1393,14 @@ function App() {
                   >
                     <span className={`agent-status-dot status-${a.status}`} />
                     <span className={`agent-kind kind-${a.kind}`}>{a.kind}</span>
+                    {a.risk && (
+                      <span
+                        className={`agent-risk risk-${a.risk}`}
+                        title={`Security risk: ${a.risk}`}
+                      >
+                        {"⛨"}
+                      </span>
+                    )}
                     <span className="agent-project">{a.project_name}</span>
                     <span className="agent-cwd" title={a.cwd}>
                       {shortenCwd(a.cwd)}
@@ -1384,6 +1447,110 @@ function App() {
     );
   }
 
+  function renderSecuritySection() {
+    const sevRank: Record<string, number> = {
+      info: 0, low: 1, medium: 2, high: 3, critical: 4,
+    };
+    const filtered = securityEvents.filter((e) =>
+      securityFilter === "all" ? true : sevRank[e.severity] >= 3,
+    );
+    const sortedDesc = [...filtered].reverse();
+    const counts: Record<string, number> = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+    for (const e of securityEvents) counts[e.severity] = (counts[e.severity] || 0) + 1;
+
+    function formatTs(iso: string) {
+      try {
+        const d = new Date(iso);
+        return d.toLocaleString();
+      } catch {
+        return iso;
+      }
+    }
+
+    return (
+      <div className="security-section">
+        <div className="security-header">
+          <div>
+            <h2>NeuralGuard Security</h2>
+            <div className="security-subhead">
+              Local AI agent runtime monitor — rules-based event feed
+            </div>
+          </div>
+          <div className="security-actions">
+            <button className="claude-btn" onClick={handleRescanSessions}>
+              Rescan sessions
+            </button>
+            <button className="claude-btn danger" onClick={handleClearSecurityEvents}>
+              Clear events
+            </button>
+          </div>
+        </div>
+
+        <div className="security-stats">
+          <div className="security-stat critical">
+            <div className="security-stat-value">{counts.critical}</div>
+            <div className="security-stat-label">Critical</div>
+          </div>
+          <div className="security-stat high">
+            <div className="security-stat-value">{counts.high}</div>
+            <div className="security-stat-label">High</div>
+          </div>
+          <div className="security-stat medium">
+            <div className="security-stat-value">{counts.medium}</div>
+            <div className="security-stat-label">Medium</div>
+          </div>
+          <div className="security-stat low">
+            <div className="security-stat-value">{counts.low}</div>
+            <div className="security-stat-label">Low</div>
+          </div>
+        </div>
+
+        <div className="security-toolbar">
+          <button
+            className={`claude-btn ${securityFilter === "all" ? "primary" : ""}`}
+            onClick={() => setSecurityFilter("all")}
+          >
+            All ({securityEvents.length})
+          </button>
+          <button
+            className={`claude-btn ${securityFilter === "high+" ? "primary" : ""}`}
+            onClick={() => setSecurityFilter("high+")}
+          >
+            High &amp; above ({counts.high + counts.critical})
+          </button>
+        </div>
+
+        <div className="security-feed">
+          {sortedDesc.length === 0 ? (
+            <div className="security-empty">
+              No security events. Run an agent and any flagged tool calls will appear here.
+            </div>
+          ) : (
+            sortedDesc.map((e) => (
+              <div key={e.id} className={`security-row severity-${e.severity}`}>
+                <div className="security-row-head">
+                  <span className={`severity-pill sev-${e.severity}`}>
+                    {e.severity.toUpperCase()}
+                  </span>
+                  <span className="security-rule">{e.rule}</span>
+                  <span className="security-tool">{e.tool}</span>
+                  <span className="security-ts">{formatTs(e.ts)}</span>
+                </div>
+                <div className="security-matched">{e.matched}</div>
+                <div className="security-meta">
+                  {e.agent_kind && <span>{e.agent_kind}</span>}
+                  {e.agent_pid && <span>pid {e.agent_pid}</span>}
+                  {e.agent_cwd && <span title={e.agent_cwd}>{e.agent_cwd.split("/").slice(-2).join("/")}</span>}
+                  <span>· {e.actor} → {e.decision}</span>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    );
+  }
+
   function usageBarColor(pct: number): string {
     if (pct >= 80) return "#ef4444";
     if (pct >= 50) return "#f59e0b";
@@ -1418,6 +1585,13 @@ function App() {
           >
             <span className="nav-item-icon">&#9881;</span>
             Agents
+          </button>
+          <button
+            className={`nav-item ${currentSection === "security" ? "active" : ""}`}
+            onClick={() => setCurrentSection("security")}
+          >
+            <span className="nav-item-icon">&#128737;</span>
+            Security
           </button>
           <button
             className={`nav-item ${currentSection === "knowledge" ? "active" : ""}`}
@@ -3514,6 +3688,7 @@ function App() {
       {renderSidebar()}
       <main className="main-content">
         {currentSection === "agents" && renderAgentsSection()}
+        {currentSection === "security" && renderSecuritySection()}
         {currentSection === "worktrees" && renderWorktreesSection()}
         {currentSection === "github" && renderGithubSection()}
         {currentSection === "knowledge" && renderKnowledgeSection()}

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -96,6 +96,16 @@ interface SecurityEvent {
   actor: string;
 }
 
+interface PendingPrompt {
+  id: string;
+  ts: string;
+  tool: string;
+  raw: unknown;
+  events: Array<{ rule: string; severity: string; matched: string }>;
+  agent_pid: number | null;
+  timeout_s: number | null;
+}
+
 interface CommandConfig {
   filename: string;
   description: string;
@@ -238,6 +248,13 @@ function App() {
   const [voiceMuted, setVoiceMuted] = useState(false);
   const [securityEvents, setSecurityEvents] = useState<SecurityEvent[]>([]);
   const [securityFilter, setSecurityFilter] = useState<"all" | "high+">("all");
+  const [neuralguardStatus, setNeuralguardStatus] = useState<{
+    installed: boolean;
+    events_path: string;
+    policy_path: string;
+    gate_script: string;
+  } | null>(null);
+  const [pendingPrompts, setPendingPrompts] = useState<PendingPrompt[]>([]);
   const [hooks, setHooks] = useState<HookConfig[]>([]);
   const [plugins, setPlugins] = useState<PluginInfo[]>([]);
   const [editingAgent, setEditingAgent] = useState<AgentConfig | null>(null);
@@ -427,9 +444,63 @@ function App() {
   useEffect(() => {
     if (currentSection !== "security") return;
     loadSecurityEvents();
+    loadNeuralguardStatus();
     const id = setInterval(loadSecurityEvents, 4000);
     return () => clearInterval(id);
   }, [currentSection]);
+
+  // Pending security prompts poll (runs always so modal can interrupt anywhere)
+  useEffect(() => {
+    loadPendingPrompts();
+    const id = setInterval(loadPendingPrompts, 1500);
+    return () => clearInterval(id);
+  }, []);
+
+  async function loadPendingPrompts() {
+    try {
+      const list = await invoke<PendingPrompt[]>("list_pending_prompts");
+      setPendingPrompts(list);
+    } catch (e) {
+      // Ignore
+    }
+  }
+
+  async function handlePromptDecision(id: string, decision: "allow" | "deny") {
+    try {
+      await invoke("respond_to_prompt", { id, decision });
+      setPendingPrompts((prev) => prev.filter((p) => p.id !== id));
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  async function loadNeuralguardStatus() {
+    try {
+      const s = await invoke<typeof neuralguardStatus>("neuralguard_status");
+      setNeuralguardStatus(s);
+    } catch (e) {
+      // Ignore
+    }
+  }
+
+  async function handleInstallHooks() {
+    try {
+      await invoke<string>("install_neuralguard_hooks");
+      loadNeuralguardStatus();
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  async function handleUninstallHooks() {
+    if (!confirm("Remove NeuralGuard from Claude Code hooks?")) return;
+    try {
+      await invoke<string>("uninstall_neuralguard_hooks");
+      loadNeuralguardStatus();
+    } catch (e) {
+      setError(String(e));
+    }
+  }
 
   async function loadSecurityEvents() {
     try {
@@ -1467,6 +1538,8 @@ function App() {
       }
     }
 
+    const installed = neuralguardStatus?.installed ?? false;
+
     return (
       <div className="security-section">
         <div className="security-header">
@@ -1483,6 +1556,30 @@ function App() {
             <button className="claude-btn danger" onClick={handleClearSecurityEvents}>
               Clear events
             </button>
+          </div>
+        </div>
+
+        <div className={`neuralguard-install ${installed ? "installed" : ""}`}>
+          <div className="neuralguard-install-text">
+            <div className="neuralguard-install-title">
+              {installed ? "NeuralGuard hooks active" : "NeuralGuard hooks not installed"}
+            </div>
+            <div className="neuralguard-install-sub">
+              {installed
+                ? "Claude Code calls go through the gate. Critical rules deny by default; edit policy.yaml to add prompt/strict modes."
+                : "Install hooks to make Claude Code consult NeuralGuard before each tool call. Until then this view is observe-only over jsonl logs."}
+            </div>
+          </div>
+          <div className="neuralguard-install-actions">
+            {installed ? (
+              <button className="claude-btn danger" onClick={handleUninstallHooks}>
+                Uninstall
+              </button>
+            ) : (
+              <button className="claude-btn primary" onClick={handleInstallHooks}>
+                Install hooks
+              </button>
+            )}
           </div>
         </div>
 
@@ -3683,9 +3780,52 @@ function App() {
     );
   }
 
+  function renderPromptModal() {
+    if (pendingPrompts.length === 0) return null;
+    const p = pendingPrompts[0];
+    const raw = (p.raw ?? {}) as Record<string, unknown>;
+    const command =
+      (raw.command as string | undefined) ??
+      (raw.file_path as string | undefined) ??
+      (raw.url as string | undefined) ??
+      JSON.stringify(p.raw, null, 2);
+    return (
+      <div className="prompt-modal-backdrop">
+        <div className="prompt-modal">
+          <div className="prompt-modal-header">
+            <span className="prompt-modal-title">⛨ NeuralGuard — confirm tool call</span>
+            <span className="prompt-modal-pid">pid {p.agent_pid ?? "?"}</span>
+          </div>
+          <div className="prompt-modal-body">
+            <div className="prompt-modal-tool">{p.tool}</div>
+            <pre className="prompt-modal-cmd">{command}</pre>
+            <div className="prompt-modal-rules">
+              {p.events.map((ev, i) => (
+                <div key={i} className={`prompt-rule sev-${ev.severity}`}>
+                  <span className={`severity-pill sev-${ev.severity}`}>{ev.severity.toUpperCase()}</span>
+                  <span>{ev.rule}</span>
+                  <span className="prompt-rule-match">{ev.matched}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="prompt-modal-footer">
+            <button className="claude-btn danger" onClick={() => handlePromptDecision(p.id, "deny")}>
+              Deny
+            </button>
+            <button className="claude-btn primary" onClick={() => handlePromptDecision(p.id, "allow")}>
+              Allow once
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="app-layout">
       {renderSidebar()}
+      {renderPromptModal()}
       <main className="main-content">
         {currentSection === "agents" && renderAgentsSection()}
         {currentSection === "security" && renderSecuritySection()}

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -82,6 +82,7 @@ interface AgentInfo {
   role: string;
   role_icon: string;
   topic: string | null;
+  name: string;
 }
 
 interface SecurityEvent {
@@ -1675,6 +1676,7 @@ function App() {
                     <span className="agent-avatar" title={a.role}>{a.role_icon}</span>
                     <span className="agent-identity">
                       <span className="agent-identity-line">
+                        <span className="agent-name">{a.name}</span>
                         <span className="agent-project">{a.project_name}</span>
                         <span className="agent-role">{a.role}</span>
                         <span className={`agent-kind kind-${a.kind}`}>{a.kind}</span>

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -78,6 +78,7 @@ interface AgentInfo {
   session_id: string | null;
   jsonl_path: string | null;
   risk: "info" | "low" | "medium" | "high" | "critical" | null;
+  risk_events: SecurityEvent[];
 }
 
 interface SecurityEvent {
@@ -1467,7 +1468,11 @@ function App() {
                     {a.risk && (
                       <span
                         className={`agent-risk risk-${a.risk}`}
-                        title={`Security risk: ${a.risk}`}
+                        title={`Security risk: ${a.risk} — ${
+                          a.risk_events.length
+                            ? a.risk_events.slice(-3).map((e) => e.rule).join(", ")
+                            : "expand for details"
+                        }`}
                       >
                         {"⛨"}
                       </span>
@@ -1494,6 +1499,24 @@ function App() {
                         <div className="agent-detail-block">
                           <div className="agent-detail-label">Last action</div>
                           <code>{a.last_action}</code>
+                        </div>
+                      )}
+                      {a.risk_events && a.risk_events.length > 0 && (
+                        <div className="agent-detail-block">
+                          <div className="agent-detail-label">
+                            Security events ({a.risk_events.length})
+                          </div>
+                          <div className="agent-risk-events">
+                            {a.risk_events.slice(-10).reverse().map((e) => (
+                              <div key={e.id} className={`agent-risk-event sev-${e.severity}`}>
+                                <span className={`severity-pill sev-${e.severity}`}>
+                                  {e.severity.toUpperCase()}
+                                </span>
+                                <span className="agent-risk-event-rule">{e.rule}</span>
+                                <span className="agent-risk-event-match">{e.matched}</span>
+                              </div>
+                            ))}
+                          </div>
                         </div>
                       )}
                       <div className="agent-detail-block agent-meta">

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -79,6 +79,9 @@ interface AgentInfo {
   jsonl_path: string | null;
   risk: "info" | "low" | "medium" | "high" | "critical" | null;
   risk_events: SecurityEvent[];
+  role: string;
+  role_icon: string;
+  topic: string | null;
 }
 
 interface SecurityEvent {
@@ -1669,24 +1672,35 @@ function App() {
                     onClick={() => setExpandedAgentPid(expanded ? null : a.pid)}
                   >
                     <span className={`agent-status-dot status-${a.status}`} />
-                    <span className={`agent-kind kind-${a.kind}`}>{a.kind}</span>
-                    {a.risk && (
-                      <span
-                        className={`agent-risk risk-${a.risk}`}
-                        title={`Security risk: ${a.risk} — ${
-                          a.risk_events.length
-                            ? a.risk_events.slice(-3).map((e) => e.rule).join(", ")
-                            : "expand for details"
-                        }`}
-                      >
-                        {"⛨"}
+                    <span className="agent-avatar" title={a.role}>{a.role_icon}</span>
+                    <span className="agent-identity">
+                      <span className="agent-identity-line">
+                        <span className="agent-project">{a.project_name}</span>
+                        <span className="agent-role">{a.role}</span>
+                        <span className={`agent-kind kind-${a.kind}`}>{a.kind}</span>
+                        {a.risk && (
+                          <span
+                            className={`agent-risk risk-${a.risk}`}
+                            title={`Security risk: ${a.risk} — ${
+                              a.risk_events.length
+                                ? a.risk_events.slice(-3).map((e) => e.rule).join(", ")
+                                : "expand for details"
+                            }`}
+                          >
+                            {"⛨"}
+                          </span>
+                        )}
+                        {a.branch && <span className="agent-branch">{a.branch}</span>}
                       </span>
-                    )}
-                    <span className="agent-project">{a.project_name}</span>
+                      {a.topic && (
+                        <span className="agent-topic" title={a.topic}>
+                          {a.topic}
+                        </span>
+                      )}
+                    </span>
                     <span className="agent-cwd" title={a.cwd}>
                       {shortenCwd(a.cwd)}
                     </span>
-                    {a.branch && <span className="agent-branch">{a.branch}</span>}
                     <span className="agent-elapsed">{elapsedSince(a.started_at)}</span>
                     <span className="agent-last-action">
                       {agentHeadline(a)}

--- a/src/synthia/hooks/security_gate.py
+++ b/src/synthia/hooks/security_gate.py
@@ -52,26 +52,72 @@ def _re(pattern: str):
     return re.compile(pattern, re.IGNORECASE)
 
 
+# Bash rules are scoped to a specific binary so they only fire when that
+# program is actually being invoked at a shell-segment boundary, not when
+# the same string appears inside an `echo`/`gh`/`git commit` quoted arg.
+#
+# (rule, severity, binaries, arg_pattern)
+#   - binaries: list of basenames; "*" matches any.
+#   - arg_pattern: regex tested against the joined args (or whole segment
+#     when binaries == "*").
 BASH_RULES = [
-    ("destructive-rm", CRITICAL, _re(r"rm\s+-rf?\s+(/|~|\$home|--no-preserve-root)")),
-    ("dd-block-device", CRITICAL, _re(r"\bdd\b.+of=/dev/(sd|nvme|hd)")),
-    ("pipe-to-shell", CRITICAL, _re(r"(curl|wget|fetch)[^|]*\|\s*(sh|bash|zsh|fish)\b")),
-    ("base64-exec", CRITICAL, _re(r"base64\s+(-d|--decode)[^|]*\|\s*(sh|bash|python|node)")),
-    ("sudo", HIGH, _re(r"\bsudo\b")),
-    ("setuid-bit", HIGH, _re(r"chmod\s+\+s\b")),
-    ("setcap", HIGH, _re(r"\bsetcap\b")),
-    ("shell-rc-tamper", HIGH, _re(r">+\s*~?/?\.(bashrc|zshrc|profile|bash_profile|zprofile)\b")),
-    ("ssh-key-access", HIGH, _re(r"~?/?\.ssh/(id_|authorized_keys|known_hosts)")),
-    ("gpg-access", HIGH, _re(r"~?/?\.gnupg/")),
-    ("aws-credentials", HIGH, _re(r"~?/?\.aws/credentials")),
+    (
+        "destructive-rm",
+        CRITICAL,
+        ["rm"],
+        _re(r"-[rR]f?\b.*(?:^|\s)(/|~|\$home|--no-preserve-root)"),
+    ),
+    ("dd-block-device", CRITICAL, ["dd"], _re(r"of=/dev/(sd|nvme|hd)")),
+    ("setuid-bit", HIGH, ["chmod"], _re(r"\+s\b")),
+    ("setcap", HIGH, ["setcap"], None),
+    (
+        "ssh-key-access",
+        HIGH,
+        ["cat", "less", "more", "head", "tail", "cp", "mv", "rm"],
+        _re(r"~?/?\.ssh/(id_|authorized_keys|known_hosts)"),
+    ),
+    (
+        "gpg-access",
+        HIGH,
+        ["cat", "less", "more", "head", "tail", "cp", "mv", "rm", "tar", "zip"],
+        _re(r"~?/?\.gnupg/"),
+    ),
+    (
+        "aws-credentials",
+        HIGH,
+        ["cat", "less", "more", "head", "tail", "cp", "mv"],
+        _re(r"~?/?\.aws/credentials"),
+    ),
     (
         "secret-exfil",
         CRITICAL,
-        _re(r"(curl|wget|scp|rsync)[^|;&\n]*(\.ssh|\.aws|\.gnupg|credentials|secret|token)"),
+        ["curl", "wget", "scp", "rsync"],
+        _re(r"(\.ssh|\.aws|\.gnupg|credentials|secret|token|api[_-]?key)"),
     ),
-    ("mass-kill", MEDIUM, _re(r"\bpkill\s+-9\b|\bkillall\s+-9\b")),
-    ("git-remote-rewrite", MEDIUM, _re(r"git\s+remote\s+(set-url|add)\s+\S+\s+(http|git@)")),
-    ("history-tamper", MEDIUM, _re(r"history\s+-c|>\s*~?/?\.(bash_history|zsh_history)")),
+    ("mass-kill", MEDIUM, ["pkill", "killall"], _re(r"-9\b")),
+    (
+        "git-remote-rewrite",
+        MEDIUM,
+        ["git"],
+        _re(r"\bremote\s+(set-url|add)\s+\S+\s+(https?:|git@)"),
+    ),
+    ("history-tamper", MEDIUM, ["history"], _re(r"-c\b")),
+]
+
+
+# Whole-segment rules — match across the segment string, not bound to one
+# binary. Used for shell features (pipes, redirections) that don't have a
+# single binary owner.
+SEGMENT_RULES = [
+    (
+        "pipe-to-shell",
+        CRITICAL,
+        _re(r"(?:^|[\s;&|])(curl|wget|fetch)\b[^|]*\|\s*(sh|bash|zsh|fish)\b"),
+    ),
+    ("base64-exec", CRITICAL, _re(r"\bbase64\s+(-d|--decode)\b[^|]*\|\s*(sh|bash|python|node)\b")),
+    ("shell-rc-tamper", HIGH, _re(r">>?\s*~?/?\.(bashrc|zshrc|profile|bash_profile|zprofile)\b")),
+    ("history-redir-tamper", MEDIUM, _re(r">\s*~?/?\.(bash_history|zsh_history)\b")),
+    ("sudo", HIGH, _re(r"(?:^|[\s;&|])sudo\b")),
 ]
 
 WRITE_RULES = [
@@ -102,14 +148,113 @@ INJECTION_RULES = [
 ]
 
 
+STATEMENT_SPLIT = re.compile(r"\s*(?:;|&&|\|\|)\s*")
+PIPE_SPLIT = re.compile(r"\s*\|(?!\|)\s*")
+ENV_ASSIGN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+
+def _split_statements(cmd: str) -> list[str]:
+    return [s.strip() for s in STATEMENT_SPLIT.split(cmd) if s.strip()]
+
+
+def _split_pipeline_stages(stmt: str) -> list[str]:
+    return [s.strip() for s in PIPE_SPLIT.split(stmt) if s.strip()]
+
+
+def _binary_of(segment: str) -> tuple[str | None, list[str]]:
+    """Return (basename, argv) for a shell segment.
+
+    Skips leading VAR=val env assignments. Falls back to whitespace split
+    if shlex chokes (e.g. unbalanced quote in an arg).
+    """
+    import shlex
+
+    try:
+        tokens = shlex.split(segment, posix=True)
+    except ValueError:
+        tokens = segment.split()
+    while tokens and ENV_ASSIGN.match(tokens[0]):
+        tokens = tokens[1:]
+    if not tokens:
+        return None, []
+    bin_name = tokens[0]
+    # strip path
+    if "/" in bin_name:
+        bin_name = bin_name.rsplit("/", 1)[-1]
+    return bin_name, tokens[1:]
+
+
+QUOTING_BINARIES = {
+    "echo",
+    "printf",
+    "gh",
+    "git",
+    "jq",
+    "awk",
+    "sed",
+    "python",
+    "python3",
+    "node",
+    "ruby",
+    "perl",
+}
+
+
+def _evaluate_bash(cmd: str) -> list[dict]:
+    hits: list[dict] = []
+    seen: set[tuple[str, str]] = set()
+
+    def emit(rule: str, sev: str, matched: str) -> None:
+        key = (rule, matched)
+        if key in seen:
+            return
+        seen.add(key)
+        hits.append({"rule": rule, "severity": sev, "matched": matched})
+
+    for stmt in _split_statements(cmd):
+        # Statement-level rules see the full pipeline (curl ... | sh) and
+        # any redirections.
+        for name, sev, pat in SEGMENT_RULES:
+            m = pat.search(stmt)
+            if m:
+                emit(name, sev, m.group(0))
+
+        # If the statement starts with a quoting/reporting binary (echo, gh,
+        # git commit, etc.), its quoted args are not real commands — skip
+        # binary-bound rules entirely for the whole statement.
+        head_bin, _ = _binary_of(stmt)
+        if head_bin in QUOTING_BINARIES:
+            continue
+
+        # Otherwise iterate pipeline stages — only the binary-bound rules
+        # for the actual program in each stage fire.
+        for stage in _split_pipeline_stages(stmt):
+            binary, args = _binary_of(stage)
+            if not binary:
+                continue
+            if binary in QUOTING_BINARIES:
+                continue
+            joined = " ".join(args)
+            for name, sev, bins, pat in BASH_RULES:
+                if bins != "*" and binary not in bins:
+                    continue
+                if pat is None:
+                    matched = binary
+                else:
+                    m = pat.search(joined)
+                    if not m:
+                        continue
+                    matched = m.group(0)
+                emit(name, sev, matched)
+
+    return hits
+
+
 def evaluate(tool: str, tool_input: dict) -> list[dict]:
     hits: list[dict] = []
     if tool == "Bash":
         cmd = tool_input.get("command", "") or ""
-        for name, sev, pat in BASH_RULES:
-            m = pat.search(cmd)
-            if m:
-                hits.append({"rule": name, "severity": sev, "matched": m.group(0)})
+        hits.extend(_evaluate_bash(cmd))
     elif tool in ("Write", "Edit", "NotebookEdit"):
         path = tool_input.get("file_path", "") or ""
         for name, sev, pat in WRITE_RULES:

--- a/src/synthia/hooks/security_gate.py
+++ b/src/synthia/hooks/security_gate.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""
+NeuralGuard PreToolUse / PostToolUse security gate.
+
+Reads Claude Code hook JSON from stdin, evaluates the proposed (or just-run)
+tool call against builtin rules + ~/.config/synthia/security/policy.yaml,
+records an event, and decides allow / deny / prompt.
+
+PreToolUse exit codes:
+  0  -> allow
+  2  -> deny (Claude shows stderr to the model)
+
+For 'prompt' decisions, this writes a pending request to
+~/.config/synthia/security/pending-prompts/<id>.json and polls for the
+matching response file; on timeout the action defaults to deny.
+
+Drop-in: register in ~/.claude/settings.json under PreToolUse and PostToolUse.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+SECURITY_DIR = Path(os.environ.get("HOME", "/tmp")) / ".config" / "synthia" / "security"
+EVENTS_PATH = SECURITY_DIR / "events.jsonl"
+POLICY_PATH = SECURITY_DIR / "policy.yaml"
+RUNTIME_PATH = Path(os.environ.get("HOME", "/tmp")) / ".config" / "synthia" / "runtime.json"
+PROMPTS_DIR = SECURITY_DIR / "pending-prompts"
+RESPONSES_DIR = SECURITY_DIR / "prompt-responses"
+
+PROMPT_TIMEOUT_S = 30
+
+
+# ---- rule engine (mirror of Rust security.rs; keep in sync) ----
+
+CRITICAL = "critical"
+HIGH = "high"
+MEDIUM = "medium"
+LOW = "low"
+INFO = "info"
+
+SEV_RANK = {INFO: 0, LOW: 1, MEDIUM: 2, HIGH: 3, CRITICAL: 4}
+
+
+def _re(pattern: str):
+    return re.compile(pattern, re.IGNORECASE)
+
+
+BASH_RULES = [
+    ("destructive-rm", CRITICAL, _re(r"rm\s+-rf?\s+(/|~|\$home|--no-preserve-root)")),
+    ("dd-block-device", CRITICAL, _re(r"\bdd\b.+of=/dev/(sd|nvme|hd)")),
+    ("pipe-to-shell", CRITICAL, _re(r"(curl|wget|fetch)[^|]*\|\s*(sh|bash|zsh|fish)\b")),
+    ("base64-exec", CRITICAL, _re(r"base64\s+(-d|--decode)[^|]*\|\s*(sh|bash|python|node)")),
+    ("sudo", HIGH, _re(r"\bsudo\b")),
+    ("setuid-bit", HIGH, _re(r"chmod\s+\+s\b")),
+    ("setcap", HIGH, _re(r"\bsetcap\b")),
+    ("shell-rc-tamper", HIGH, _re(r">+\s*~?/?\.(bashrc|zshrc|profile|bash_profile|zprofile)\b")),
+    ("ssh-key-access", HIGH, _re(r"~?/?\.ssh/(id_|authorized_keys|known_hosts)")),
+    ("gpg-access", HIGH, _re(r"~?/?\.gnupg/")),
+    ("aws-credentials", HIGH, _re(r"~?/?\.aws/credentials")),
+    (
+        "secret-exfil",
+        CRITICAL,
+        _re(r"(curl|wget|scp|rsync)[^|;&\n]*(\.ssh|\.aws|\.gnupg|credentials|secret|token)"),
+    ),
+    ("mass-kill", MEDIUM, _re(r"\bpkill\s+-9\b|\bkillall\s+-9\b")),
+    ("git-remote-rewrite", MEDIUM, _re(r"git\s+remote\s+(set-url|add)\s+\S+\s+(http|git@)")),
+    ("history-tamper", MEDIUM, _re(r"history\s+-c|>\s*~?/?\.(bash_history|zsh_history)")),
+]
+
+WRITE_RULES = [
+    ("ssh-key-write", CRITICAL, _re(r"\.ssh/(id_|authorized_keys)")),
+    ("shell-rc-write", HIGH, _re(r"\.(bashrc|zshrc|profile|bash_profile|zprofile)$")),
+    ("env-file-write", MEDIUM, _re(r"\.env(\.|$)")),
+    ("system-config-write", HIGH, _re(r"^/etc/")),
+]
+
+READ_RULES = [
+    ("ssh-key-read", HIGH, _re(r"\.ssh/(id_|authorized_keys)")),
+    ("credentials-read", HIGH, _re(r"\.aws/credentials|\.gnupg/")),
+]
+
+FETCH_RULES = [
+    ("fetch-ip-literal", MEDIUM, _re(r"^https?://\d+\.\d+\.\d+\.\d+")),
+    ("fetch-onion", HIGH, _re(r"\.onion/")),
+]
+
+INJECTION_RULES = [
+    ("injection-ignore-previous", HIGH, _re(r"ignore\s+(all\s+)?previous\s+instructions")),
+    (
+        "injection-roleplay",
+        HIGH,
+        _re(r"you\s+are\s+now\s+(a\s+)?[a-z\s]{0,30}(jailbreak|developer\s*mode|dan)"),
+    ),
+    ("injection-system-marker", MEDIUM, _re(r"\[SYSTEM\]|<system>|###\s*system\s*###")),
+]
+
+
+def evaluate(tool: str, tool_input: dict) -> list[dict]:
+    hits: list[dict] = []
+    if tool == "Bash":
+        cmd = tool_input.get("command", "") or ""
+        for name, sev, pat in BASH_RULES:
+            m = pat.search(cmd)
+            if m:
+                hits.append({"rule": name, "severity": sev, "matched": m.group(0)})
+    elif tool in ("Write", "Edit", "NotebookEdit"):
+        path = tool_input.get("file_path", "") or ""
+        for name, sev, pat in WRITE_RULES:
+            m = pat.search(path)
+            if m:
+                hits.append({"rule": name, "severity": sev, "matched": path})
+    elif tool == "Read":
+        path = tool_input.get("file_path", "") or ""
+        for name, sev, pat in READ_RULES:
+            m = pat.search(path)
+            if m:
+                hits.append({"rule": name, "severity": sev, "matched": path})
+    elif tool == "WebFetch":
+        url = tool_input.get("url", "") or ""
+        for name, sev, pat in FETCH_RULES:
+            m = pat.search(url)
+            if m:
+                hits.append({"rule": name, "severity": sev, "matched": url})
+    return hits
+
+
+def evaluate_injection(text: str) -> list[dict]:
+    hits: list[dict] = []
+    if not text:
+        return hits
+    for name, sev, pat in INJECTION_RULES:
+        m = pat.search(text)
+        if m:
+            hits.append({"rule": name, "severity": sev, "matched": m.group(0)})
+    # zero-width / unicode tag chars
+    if any(0x200B <= ord(c) <= 0x200F or 0xE0000 <= ord(c) <= 0xE007F for c in text):
+        hits.append(
+            {"rule": "injection-hidden-unicode", "severity": HIGH, "matched": "zero-width chars"}
+        )
+    return hits
+
+
+# ---- policy ----
+
+
+def load_policy() -> dict:
+    """Load policy.yaml; falls back to permissive defaults.
+
+    Tries PyYAML if available, otherwise minimal manual parse for the
+    `default:`, `mode:` and `block_on:` top-level keys.
+    """
+    if not POLICY_PATH.exists():
+        return {"default": "allow", "mode": "permissive", "block_on": ["critical"]}
+    text = POLICY_PATH.read_text(encoding="utf-8")
+    try:
+        import yaml  # type: ignore
+
+        data = yaml.safe_load(text) or {}
+        return data
+    except Exception:
+        out: dict = {}
+        for line in text.splitlines():
+            if ":" not in line or line.strip().startswith("#"):
+                continue
+            k, _, v = line.partition(":")
+            out[k.strip()] = v.strip().strip("\"'")
+        return out
+
+
+def is_paused() -> bool:
+    try:
+        with open(RUNTIME_PATH, encoding="utf-8") as f:
+            return bool(json.load(f).get("security_paused", False))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return False
+
+
+# ---- event recording ----
+
+
+def append_event(event: dict) -> None:
+    SECURITY_DIR.mkdir(parents=True, exist_ok=True)
+    with EVENTS_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(event) + "\n")
+
+
+def make_event(hit: dict, tool: str, raw: dict, decision: str, actor: str, ctx: dict) -> dict:
+    return {
+        "id": f"evt_{uuid.uuid4().hex[:12]}",
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "agent_pid": os.getppid(),
+        "agent_kind": "claude",
+        "agent_cwd": ctx.get("cwd"),
+        "session_id": ctx.get("session_id"),
+        "tool": tool,
+        "rule": hit["rule"],
+        "severity": hit["severity"],
+        "matched": hit["matched"],
+        "raw": raw,
+        "decision": decision,
+        "actor": actor,
+    }
+
+
+# ---- prompt-and-wait flow ----
+
+
+def request_user_decision(events: list[dict], tool: str, raw: dict) -> str:
+    """Write a pending prompt and wait for the GUI to drop a response file.
+
+    Returns 'allow' or 'deny'. Defaults to deny on timeout.
+    """
+    PROMPTS_DIR.mkdir(parents=True, exist_ok=True)
+    RESPONSES_DIR.mkdir(parents=True, exist_ok=True)
+    req_id = uuid.uuid4().hex
+    payload = {
+        "id": req_id,
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "tool": tool,
+        "raw": raw,
+        "events": events,
+        "agent_pid": os.getppid(),
+        "timeout_s": PROMPT_TIMEOUT_S,
+    }
+    (PROMPTS_DIR / f"{req_id}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    response_file = RESPONSES_DIR / f"{req_id}.json"
+    deadline = time.monotonic() + PROMPT_TIMEOUT_S
+    while time.monotonic() < deadline:
+        if response_file.exists():
+            try:
+                resp = json.loads(response_file.read_text(encoding="utf-8"))
+                response_file.unlink(missing_ok=True)
+                (PROMPTS_DIR / f"{req_id}.json").unlink(missing_ok=True)
+                return "allow" if resp.get("decision") == "allow" else "deny"
+            except Exception:
+                break
+        time.sleep(0.25)
+    # timeout: clean up request and deny
+    (PROMPTS_DIR / f"{req_id}.json").unlink(missing_ok=True)
+    return "deny"
+
+
+# ---- entrypoint ----
+
+
+def main() -> int:
+    try:
+        payload = json.loads(sys.stdin.read() or "{}")
+    except json.JSONDecodeError:
+        return 0  # don't block claude on parse errors
+
+    hook_event = payload.get("hook_event_name") or payload.get("event") or "PreToolUse"
+    tool = payload.get("tool_name") or payload.get("tool", "")
+    tool_input = payload.get("tool_input", {}) or {}
+    tool_output = payload.get("tool_response") or payload.get("tool_output", "")
+    ctx = {
+        "cwd": payload.get("cwd"),
+        "session_id": payload.get("session_id"),
+    }
+
+    if hook_event == "PostToolUse":
+        text = tool_output if isinstance(tool_output, str) else json.dumps(tool_output)
+        hits = evaluate_injection(text)
+        for h in hits:
+            append_event(
+                make_event(h, tool, {"output_excerpt": text[:500]}, "observed", "rule-engine", ctx)
+            )
+        return 0
+
+    # PreToolUse path
+    hits = evaluate(tool, tool_input)
+    if not hits:
+        return 0
+
+    policy = load_policy()
+    block_on = policy.get("block_on", ["critical"])
+    if isinstance(block_on, str):
+        block_on = [block_on]
+    mode = policy.get("mode", "permissive")
+    paused = is_paused()
+
+    max_rank = max(SEV_RANK.get(h["severity"], 0) for h in hits)
+    severity_max = next(name for name, r in SEV_RANK.items() if r == max_rank)
+    should_block = severity_max in block_on or (mode == "strict" and max_rank >= SEV_RANK[MEDIUM])
+    should_prompt = mode == "prompt" or (severity_max == HIGH and "high" not in block_on)
+
+    if paused:
+        for h in hits:
+            append_event(make_event(h, tool, tool_input, "observed", "rule-engine", ctx))
+        return 0
+
+    if should_block:
+        for h in hits:
+            append_event(make_event(h, tool, tool_input, "denied", "policy-default", ctx))
+        sys.stderr.write(
+            f"NeuralGuard blocked {tool} call. Rule(s): "
+            + ", ".join(h["rule"] for h in hits)
+            + ". Edit ~/.config/synthia/security/policy.yaml to adjust.\n"
+        )
+        return 2
+
+    if should_prompt:
+        decision = request_user_decision(hits, tool, tool_input)
+        for h in hits:
+            append_event(
+                make_event(
+                    h, tool, tool_input, "allowed" if decision == "allow" else "denied", "user", ctx
+                )
+            )
+        if decision == "deny":
+            sys.stderr.write("NeuralGuard: user denied this tool call.\n")
+            return 2
+        return 0
+
+    # observe-only path
+    for h in hits:
+        append_event(make_event(h, tool, tool_input, "observed", "rule-engine", ctx))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/synthia/hooks/security_gate.py
+++ b/src/synthia/hooks/security_gate.py
@@ -327,6 +327,124 @@ def is_paused() -> bool:
         return False
 
 
+# ---- LLM classifier (optional second-pass intent check) ----
+
+LLM_CACHE_PATH = SECURITY_DIR / "llm_cache.json"
+LLM_CACHE_TTL_S = 3600
+LLM_DEFAULT_MODEL = "claude-haiku-4-5-20251001"
+LLM_TIMEOUT_S = 6
+
+
+def _llm_cache_load() -> dict:
+    try:
+        return json.loads(LLM_CACHE_PATH.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+
+
+def _llm_cache_save(data: dict) -> None:
+    SECURITY_DIR.mkdir(parents=True, exist_ok=True)
+    LLM_CACHE_PATH.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _llm_cache_key(tool: str, tool_input: dict) -> str:
+    import hashlib
+
+    blob = json.dumps({"tool": tool, "input": tool_input}, sort_keys=True)
+    return hashlib.sha256(blob.encode()).hexdigest()
+
+
+def _read_oauth_token() -> str | None:
+    try:
+        creds = json.loads(
+            (Path.home() / ".claude" / ".credentials.json").read_text(encoding="utf-8")
+        )
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+    return (creds.get("claudeAiOauth") or {}).get("accessToken")
+
+
+def llm_classify(
+    tool: str, tool_input: dict, hits: list[dict], cfg: dict
+) -> tuple[str, str] | None:
+    """Second-pass LLM intent check.
+
+    Returns (severity, reason) or None when classification is unavailable
+    or skipped (no creds, library missing, cached miss, etc).
+    """
+    if not cfg.get("enabled"):
+        return None
+    threshold = cfg.get("threshold", "medium")
+    threshold_rank = SEV_RANK.get(threshold, SEV_RANK[MEDIUM])
+    max_rank = max((SEV_RANK.get(h["severity"], 0) for h in hits), default=0)
+    if max_rank < threshold_rank:
+        return None
+
+    cache = _llm_cache_load()
+    key = _llm_cache_key(tool, tool_input)
+    now = time.time()
+    cached = cache.get(key)
+    if cached and now - cached.get("ts", 0) < LLM_CACHE_TTL_S:
+        return cached.get("severity"), cached.get("reason", "")
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY") or _read_oauth_token()
+    if not api_key:
+        return None
+
+    try:
+        import anthropic  # type: ignore
+    except Exception:
+        return None
+
+    model = cfg.get("model", LLM_DEFAULT_MODEL)
+    rule_summary = ", ".join(f"{h['rule']}({h['severity']})" for h in hits)
+    user_block = json.dumps({"tool": tool, "input": tool_input}, indent=2)[:2000]
+
+    prompt = (
+        "You are a security analyst auditing a tool call about to be run "
+        "by a developer's local AI coding agent. Local rules already "
+        f"flagged this call (rule hits: {rule_summary}). Decide if this "
+        "is genuinely malicious / dangerous given the visible intent, or "
+        "a benign developer action that the static rules over-flagged. "
+        "Reply with strict JSON only: "
+        '{"severity":"info|low|medium|high|critical","reason":"<one short sentence>"}'
+    )
+
+    try:
+        kwargs: dict = {"timeout": LLM_TIMEOUT_S}
+        if api_key.startswith("sk-ant-oat"):
+            # OAuth token from Claude Code
+            client = anthropic.Anthropic(auth_token=api_key, **kwargs)
+        else:
+            client = anthropic.Anthropic(api_key=api_key, **kwargs)
+        msg = client.messages.create(
+            model=model,
+            max_tokens=200,
+            system=prompt,
+            messages=[{"role": "user", "content": f"Tool call:\n{user_block}"}],
+        )
+    except Exception:
+        return None
+
+    text = "".join(b.text for b in msg.content if getattr(b, "type", "") == "text").strip()
+    sev = MEDIUM
+    reason = ""
+    try:
+        # Tolerate fenced code or stray prose
+        m = re.search(r"\{[^{}]*\"severity\"[^{}]*\}", text, re.DOTALL)
+        data = json.loads(m.group(0) if m else text)
+        sev = (data.get("severity") or MEDIUM).lower()
+        if sev not in SEV_RANK:
+            sev = MEDIUM
+        reason = (data.get("reason") or "").strip()
+    except Exception:
+        return None
+
+    cache[key] = {"ts": now, "severity": sev, "reason": reason}
+    _llm_cache_save(cache)
+    return sev, reason
+
+
 # ---- event recording ----
 
 
@@ -432,10 +550,28 @@ def main() -> int:
     mode = policy.get("mode", "permissive")
     paused = is_paused()
 
+    # Optional second-pass: ask Claude Haiku whether the static-rule
+    # flags really look malicious. Result can DOWNGRADE (treat as info,
+    # let the call through) or UPGRADE (force a deny on a high hit).
+    llm_cfg = policy.get("llm_classifier") or {}
+    llm_result = llm_classify(tool, tool_input, hits, llm_cfg) if not paused else None
+    llm_severity, llm_reason = llm_result if llm_result else (None, None)
+
     max_rank = max(SEV_RANK.get(h["severity"], 0) for h in hits)
+    if llm_severity is not None:
+        llm_rank = SEV_RANK.get(llm_severity, max_rank)
+        # Always defer to LLM verdict when it is available (it has more
+        # context than the regex). Annotate every hit with the new
+        # severity so the event log reflects the verdict.
+        max_rank = llm_rank
+        for h in hits:
+            h["severity"] = llm_severity
+            h["matched"] = (h.get("matched", "") + f"  [llm: {llm_reason}]").strip()
     severity_max = next(name for name, r in SEV_RANK.items() if r == max_rank)
     should_block = severity_max in block_on or (mode == "strict" and max_rank >= SEV_RANK[MEDIUM])
     should_prompt = mode == "prompt" or (severity_max == HIGH and "high" not in block_on)
+
+    actor = "llm-classifier" if llm_severity is not None else "rule-engine"
 
     if paused:
         for h in hits:
@@ -444,10 +580,12 @@ def main() -> int:
 
     if should_block:
         for h in hits:
-            append_event(make_event(h, tool, tool_input, "denied", "policy-default", ctx))
+            append_event(make_event(h, tool, tool_input, "denied", actor, ctx))
+        suffix = f" — {llm_reason}" if llm_reason else ""
         sys.stderr.write(
             f"NeuralGuard blocked {tool} call. Rule(s): "
             + ", ".join(h["rule"] for h in hits)
+            + suffix
             + ". Edit ~/.config/synthia/security/policy.yaml to adjust.\n"
         )
         return 2


### PR DESCRIPTION
## Summary

Turns Synthia into a runtime security layer for local AI coding agents (Claude Code, OpenCode, Kimi, Codex). Introduces an "AI Security" tab with two layers — observation and prevention — plus persona-style agent identity tweaks across the rest of the GUI.

## Observation layer

- New `gui/src-tauri/src/security.rs` rule engine with ~25 builtin detection rules across Bash (tokenized into pipeline stages so quoted examples don't trip), Read/Write/Edit, WebFetch, plus prompt-injection signatures.
- Severity ladder info < low < medium < high < critical; events appended to `~/.config/synthia/security/events.jsonl` with a per-session line cursor.
- `list_active_agents` incrementally scans the latest jsonl per Claude agent and surfaces worst severity as a shield badge on each row, with an expanded list of recent rule hits in the agent detail panel.
- New **AI Security** sidebar tab with a stats strip, severity filter, rescan + clear actions, and a feed of recent events. Each event shows a friendly `What:` / `Why risky:` / `What to do:` block plus an outcome pill (`Blocked before running` / `Allowed by you — ran` / `Already ran (caught after the fact)` / `Connection observed` / `Awaiting your decision`).

## Prevention layer

- `src/synthia/hooks/security_gate.py`: PreToolUse + PostToolUse hook. Mirrors the Rust rule engine, evaluates against `policy.yaml` (defaults permissive, critical denies), and decides allow / deny / prompt.
- Optional second-pass LLM classifier (Claude Haiku) for ambiguous cases; reuses the user's Claude Code OAuth token, results cached 1h. Off by default.
- Egress monitor background thread: polls `ss` every 30s, flags outbound TCP from agent processes to hosts not on the dev/AI allowlist (api.anthropic.com, github.com, registry.npmjs.org, pypi.org, etc.). Toggle in the Security tab.
- Prompt flow uses on-disk request/response files between hook and GUI; 30s timeout defaults to deny.
- Tauri install/uninstall idempotently patch `~/.claude/settings.json`.
- GUI polls pending prompts every 1.5s and shows a blocking modal anywhere in the app with rule details + Allow/Deny.

## Agent identity / UX (in the same branch)

- Each tracked agent now gets a deterministic friendly name (Atlas / Maeve / Felix / Iris / etc.), a person-shaped emoji avatar, and a role pill picked from work pattern: Developer / Technical Writer / Architect / Orchestrator / DevOps / Researcher.
- Italic headline pulled from the latest TaskCreate/TaskUpdate `in_progress` todo so the agent reads as actively working on something specific.
- Friendly activity verb ("Reading types.ts", "Editing payment-flow.ts", "Running git", "Fetching github.com") replaces the raw last-action string.
- Agents that share a cwd (e.g. multiple worktrees of the same repo) are now correctly matched to their own jsonl session via start-time matching.

## Test plan

- Click **Install hooks** in AI Security tab; verify `~/.claude/settings.json` PreToolUse + PostToolUse contain the gate command.
- In another Claude session run `rm -rf ~/test` → tool blocks, error shown to model, event appears with severity critical and outcome `Blocked before running`.
- Run `ls` → no event, no block.
- Trigger an injection-flagged WebFetch result → high event recorded; tool still passes through (observe-only).
- Click **Uninstall** → settings restored, no gate entries.
- Set `mode: prompt` in `~/.config/synthia/security/policy.yaml` → run `sudo apt update` from Claude → modal pops in GUI; Allow → runs, Deny → blocked.
- Toggle the egress monitor → verify TCP connections from claude/opencode/kimi/codex to a non-allowlisted IP show up.
- Confirm two Claude agents in different worktrees of the same repo show different last actions and topics.

## Out of scope

- Sandboxed execution (firejail / bubblewrap profiles).
- OpenCode / Kimi / Codex hook coverage (they don't have stable PreToolUse hooks yet) — those agents are observed via process scan only.
- Cross-machine fleet view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
