### PR TITLE
feat(product): embedded Product dashboard tab

### DIFF
--- a/docs/superpowers/plans/2026-07-17-product-dashboard-tab.md
+++ b/docs/superpowers/plans/2026-07-17-product-dashboard-tab.md
@@ -1,0 +1,445 @@
+# Product Dashboard Tab Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Product" tab to the Synthia Tauri GUI that embeds the existing eventflo Product Dashboard and keeps it live via Synthia-owned refresh.
+
+**Architecture:** Two Rust IPC commands (`get_product_dashboard_html`, `refresh_product_dashboard`) in a new `commands/product.rs`, plus a React `renderProductSection()` that shows the assembled HTML in an `<iframe srcDoc>`. The HTML command inlines the `data/dashboard.js` sidecar into `dashboard.html` and rewrites its loader so the embedded frame reads inlined data instead of fetching a file. The refresh command shells out to `refresh.sh`. The source tool at `~/.claude/tools/product-dashboard/` is never modified.
+
+**Tech Stack:** Rust + Tauri v2, React + TypeScript, `@tauri-apps/api/core` `invoke`.
+
+## Global Constraints
+
+- Dashboard dir: `~/.claude/tools/product-dashboard` (resolved via `get_claude_dir().join("tools/product-dashboard")`).
+- Rust errors use the existing typed `AppError` (variants: `Io`, `Path`, `Validation`, `NotFound`, `Process`, …). No `unwrap()` on I/O.
+- Rust clippy gate: zero warnings (`cargo clippy --all-targets -- -D warnings`).
+- Do NOT modify the source tool files under `~/.claude/tools/product-dashboard/`.
+- Auto-refresh interval: **15 minutes**, hard-coded constant, only while the Product section is active.
+- Brand: "Product Dashboard" title; keep capital-S "Synthia".
+
+---
+
+### Task 1: Rust command — assemble embedded dashboard HTML
+
+**Files:**
+- Create: `gui/src-tauri/src/commands/product.rs`
+- Modify: `gui/src-tauri/src/commands/mod.rs` (add `pub mod product;`)
+- Modify: `gui/src-tauri/src/lib.rs` (add `get_product_dashboard_dir()` helper + register command in `generate_handler!`)
+
+**Interfaces:**
+- Consumes: `crate::error::AppError`, `crate::get_claude_dir` (existing, in `lib.rs`).
+- Produces:
+  - `pub(crate) fn get_product_dashboard_dir() -> PathBuf` (in `lib.rs`)
+  - `pub fn build_embedded_html(html: &str, sidecar_js: &str) -> String` (in `product.rs`)
+  - `#[tauri::command] pub async fn get_product_dashboard_html() -> Result<String, AppError>`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `gui/src-tauri/src/commands/product.rs` with only the test + a stub:
+
+```rust
+//! Product Dashboard Tauri commands.
+//!
+//! Embeds the existing eventflo Product Dashboard (`~/.claude/tools/product-dashboard/`)
+//! into the GUI. `dashboard.html` normally loads its data from a relative
+//! `data/dashboard.js` sidecar (falling back to `fetch`) — neither works inside an
+//! embedded iframe, so we inline the sidecar and rewrite the loader to read the
+//! inlined global. The source tool is never modified.
+
+use crate::error::AppError;
+use crate::get_product_dashboard_dir;
+
+/// Inline the data sidecar into the page and rewrite the loader so an embedded
+/// frame reads `window.DASHBOARD_DATA` directly instead of loading a file.
+pub fn build_embedded_html(html: &str, sidecar_js: &str) -> String {
+    // Neutralize any literal </script> inside JSON string values so the inline
+    // script tag can't be closed early.
+    let safe = sidecar_js.replace("</script>", "<\\/script>");
+    let injected = format!("<head>\n  <script>{safe}</script>");
+    html.replacen("<head>", &injected, 1).replace(
+        "return loadSidecar().then(data =>",
+        "return Promise.resolve(window.DASHBOARD_DATA).then(data =>",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embeds_data_and_rewrites_loader() {
+        let html = "<html><head>\n</head><body><script>\n    function loadSidecar(){}\n    function loadData(){ return loadSidecar().then(data => data); }\n</script></body></html>";
+        let sidecar = "window.DASHBOARD_DATA = {\"x\":1};\n";
+
+        let out = build_embedded_html(html, sidecar);
+
+        assert!(out.contains("window.DASHBOARD_DATA = {\"x\":1};"), "sidecar inlined");
+        assert!(out.contains("Promise.resolve(window.DASHBOARD_DATA).then(data =>"), "loader rewritten");
+        assert!(!out.contains("return loadSidecar().then(data =>"), "old loader call gone");
+    }
+
+    #[test]
+    fn escapes_nested_script_close() {
+        let html = "<head>\n</head>";
+        let sidecar = "window.DASHBOARD_DATA = {\"t\":\"a</script>b\"};";
+        let out = build_embedded_html(html, sidecar);
+        assert!(!out.contains("a</script>b"), "nested close escaped");
+        assert!(out.contains("a<\\/script>b"), "escaped form present");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd gui/src-tauri && cargo test --lib product`
+Expected: compile error — `get_product_dashboard_dir` and `AppError` import unused / `get_product_dashboard_dir` not found (helper added next step). If it compiles and passes the two `build_embedded_html` tests already, that is acceptable (the transform is pure); proceed.
+
+- [ ] **Step 3: Add the dir helper and the command**
+
+In `gui/src-tauri/src/lib.rs`, next to `get_claude_dir()` / `get_memory_dir()`:
+
+```rust
+pub(crate) fn get_product_dashboard_dir() -> PathBuf {
+    get_claude_dir().join("tools/product-dashboard")
+}
+```
+
+Append to `gui/src-tauri/src/commands/product.rs` (after `build_embedded_html`, before `#[cfg(test)]`):
+
+```rust
+/// Return the fully self-contained dashboard HTML with data inlined.
+#[tauri::command]
+pub async fn get_product_dashboard_html() -> Result<String, AppError> {
+    let dir = get_product_dashboard_dir();
+    let html_path = dir.join("dashboard.html");
+    if !html_path.exists() {
+        return Err(AppError::NotFound(
+            "Product dashboard not found — run the morning tool once to generate it.".into(),
+        ));
+    }
+    let html = std::fs::read_to_string(&html_path).map_err(|e| AppError::Io(e.to_string()))?;
+    // Sidecar may not exist yet (never refreshed); the page has its own no-data
+    // handling and the first background refresh will generate it.
+    let sidecar = std::fs::read_to_string(dir.join("data/dashboard.js")).unwrap_or_default();
+    Ok(build_embedded_html(&html, &sidecar))
+}
+```
+
+In `gui/src-tauri/src/commands/mod.rs`, add (alphabetical order, after `pub mod overlay;`):
+
+```rust
+pub mod product;
+```
+
+In `gui/src-tauri/src/lib.rs` `generate_handler!` list, add near the other command entries:
+
+```rust
+            commands::product::get_product_dashboard_html,
+```
+
+- [ ] **Step 4: Run tests + clippy to verify pass**
+
+Run: `cd gui/src-tauri && cargo test --lib product && cargo clippy --all-targets -- -D warnings`
+Expected: both `product::tests` pass; zero clippy warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gui/src-tauri/src/commands/product.rs gui/src-tauri/src/commands/mod.rs gui/src-tauri/src/lib.rs
+git commit -m "feat(product): get_product_dashboard_html command with inlined data"
+```
+
+---
+
+### Task 2: Rust command — refresh the dashboard data
+
+**Files:**
+- Modify: `gui/src-tauri/src/commands/product.rs` (add `refresh_product_dashboard`)
+- Modify: `gui/src-tauri/src/lib.rs` (register command)
+
+**Interfaces:**
+- Consumes: `get_product_dashboard_dir`, `AppError`, `tauri::async_runtime::spawn_blocking`.
+- Produces: `#[tauri::command] pub async fn refresh_product_dashboard() -> Result<String, AppError>` (returns `"refreshed"` on success).
+
+- [ ] **Step 1: Add the command**
+
+Append to `gui/src-tauri/src/commands/product.rs` (before `#[cfg(test)]`):
+
+```rust
+/// Regenerate the dashboard data by running the tool's `refresh.sh`.
+/// Runs off the UI thread; `refresh.sh` keeps prior data on partial failure.
+#[tauri::command]
+pub async fn refresh_product_dashboard() -> Result<String, AppError> {
+    let dir = get_product_dashboard_dir();
+    if !dir.join("refresh.sh").exists() {
+        return Err(AppError::NotFound("refresh.sh not found".into()));
+    }
+    let output = tauri::async_runtime::spawn_blocking(move || {
+        std::process::Command::new("bash")
+            .arg("refresh.sh")
+            .current_dir(&dir)
+            .output()
+    })
+    .await
+    .map_err(|e| AppError::Process(e.to_string()))?
+    .map_err(|e| AppError::Process(e.to_string()))?;
+
+    if !output.status.success() {
+        return Err(AppError::Process(format!(
+            "refresh.sh failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    Ok("refreshed".to_string())
+}
+```
+
+- [ ] **Step 2: Register the command**
+
+In `gui/src-tauri/src/lib.rs` `generate_handler!`, add below the previous entry:
+
+```rust
+            commands::product::refresh_product_dashboard,
+```
+
+- [ ] **Step 3: Build + clippy to verify it compiles clean**
+
+Run: `cd gui/src-tauri && cargo build && cargo clippy --all-targets -- -D warnings`
+Expected: builds; zero warnings. (No unit test — this shells out to `gh`; verified manually in Task 4.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add gui/src-tauri/src/commands/product.rs gui/src-tauri/src/lib.rs
+git commit -m "feat(product): refresh_product_dashboard command runs refresh.sh"
+```
+
+---
+
+### Task 3: Frontend — Product tab
+
+**Files:**
+- Modify: `gui/src/App.tsx` (Section union, state, nav button, `renderProductSection`, load/refresh functions, effect, main-content wiring)
+- Modify: `gui/src/App.css` (product panel styles)
+
+**Interfaces:**
+- Consumes: Rust commands `get_product_dashboard_html` (`-> string`), `refresh_product_dashboard` (`-> string`).
+- Produces: `renderProductSection()` used in the `<main className="main-content">` switch.
+
+- [ ] **Step 1: Add `"product"` to the Section union**
+
+`gui/src/App.tsx:398` — change:
+
+```tsx
+type Section = "worktrees" | "knowledge" | "agents" | "security" | "voice" | "memory" | "config" | "github";
+```
+to:
+```tsx
+type Section = "worktrees" | "knowledge" | "agents" | "security" | "voice" | "memory" | "config" | "github" | "product";
+```
+
+- [ ] **Step 2: Add state (near the GitHub state block around line 516-525)**
+
+```tsx
+  // Product dashboard state
+  const [productHtml, setProductHtml] = useState<string>("");
+  const [productError, setProductError] = useState<string | null>(null);
+  const [productRefreshing, setProductRefreshing] = useState(false);
+  const [productRefreshedAt, setProductRefreshedAt] = useState<string>("");
+```
+
+- [ ] **Step 3: Add load + refresh functions and the section renderer**
+
+Add alongside the other `renderXSection` functions (e.g. after `renderGithubSection`):
+
+```tsx
+  async function loadProductHtml() {
+    try {
+      const html = await invoke<string>("get_product_dashboard_html");
+      setProductHtml(html);
+      setProductError(null);
+    } catch (e) {
+      setProductError(typeof e === "string" ? e : JSON.stringify(e));
+    }
+  }
+
+  async function refreshProductDashboard() {
+    setProductRefreshing(true);
+    try {
+      await invoke("refresh_product_dashboard");
+      await loadProductHtml();
+      setProductRefreshedAt(new Date().toLocaleTimeString("en-AU"));
+    } catch (e) {
+      setProductError(typeof e === "string" ? e : JSON.stringify(e));
+    } finally {
+      setProductRefreshing(false);
+    }
+  }
+
+  function renderProductSection() {
+    return (
+      <div className="product-section">
+        <div className="product-toolbar">
+          <span className="product-title">Product Dashboard</span>
+          <span className="product-status">
+            {productRefreshing
+              ? "Refreshing…"
+              : productRefreshedAt
+              ? `Updated ${productRefreshedAt}`
+              : ""}
+          </span>
+          <button
+            className="task-panel-btn primary"
+            onClick={refreshProductDashboard}
+            disabled={productRefreshing}
+          >
+            Refresh
+          </button>
+        </div>
+        {productError ? (
+          <div className="product-empty">{productError}</div>
+        ) : (
+          <iframe
+            className="product-frame"
+            title="Product Dashboard"
+            srcDoc={productHtml}
+          />
+        )}
+      </div>
+    );
+  }
+```
+
+- [ ] **Step 4: Add the load-on-open + interval effect**
+
+Add a new `useEffect` alongside the other section effects (near line 649-669):
+
+```tsx
+  useEffect(() => {
+    if (currentSection !== "product") return;
+    loadProductHtml();
+    refreshProductDashboard();
+    const id = setInterval(refreshProductDashboard, 15 * 60 * 1000);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentSection]);
+```
+
+- [ ] **Step 5: Add the nav button**
+
+In the `<nav>` block, after the GitHub nav-item (around line 2291-2297), add:
+
+```tsx
+          <button
+            className={`nav-item ${currentSection === "product" ? "active" : ""}`}
+            onClick={() => setCurrentSection("product")}
+          >
+            <span className="nav-item-icon">&#128202;</span>
+            Product
+          </button>
+```
+
+- [ ] **Step 6: Wire into main-content switch**
+
+At `gui/src/App.tsx` ~line 4425, add inside `<main className="main-content">`:
+
+```tsx
+          {currentSection === "product" && renderProductSection()}
+```
+
+- [ ] **Step 7: Add CSS**
+
+Append to `gui/src/App.css`:
+
+```css
+.product-section {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+.product-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+.product-title { font-weight: 600; }
+.product-status { color: #9a9aa8; font-size: 12px; margin-left: auto; }
+.product-frame {
+  flex: 1;
+  width: 100%;
+  border: none;
+  background: #08080c;
+}
+.product-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #9a9aa8;
+  padding: 40px;
+  text-align: center;
+}
+```
+
+- [ ] **Step 8: Typecheck + build the frontend**
+
+Run: `cd gui && npm run build`
+Expected: TypeScript compiles, Vite build succeeds, no unused-var errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add gui/src/App.tsx gui/src/App.css
+git commit -m "feat(product): Product dashboard tab with embedded iframe + auto-refresh"
+```
+
+---
+
+### Task 4: Build the app + manual verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full release build**
+
+Run: `cd gui/src-tauri && cargo build --release`
+Expected: builds clean.
+
+- [ ] **Step 2: Launch the dev GUI**
+
+Kill any running instance first (an old process blocks the new one), then run the app (`cd gui && npm run tauri dev`, or the project's usual launch). Confirm no console errors on startup.
+
+- [ ] **Step 3: Verify the tab**
+
+- Click the **Product** nav item → the dashboard panels render inside the iframe (bugs / car park / tasks / release / PRs / deploys panels visible).
+- The toolbar shows "Refreshing…" then "Updated <time>" after the initial background refresh completes.
+- Click **Refresh** → status returns to "Refreshing…" then updates; panel data reloads.
+- Switch to another tab and back → no duplicate intervals / errors in the console.
+- Temporarily rename `~/.claude/tools/product-dashboard/dashboard.html` and reopen the tab → friendly "not found" message shows instead of a crash. Restore the file.
+
+- [ ] **Step 4: Final commit (if any tweaks were needed)**
+
+```bash
+git add -A
+git commit -m "fix(product): verification tweaks"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Embed existing HTML → Task 1 (`build_embedded_html` + `get_product_dashboard_html`). ✓
+- New Product sidebar tab → Task 3 (Section union, nav button, main-content switch). ✓
+- Synthia owns refresh (on-open + manual + 15-min interval) → Task 2 (command) + Task 3 (functions + effect). ✓
+- Inline data + loader rewrite (no CORS/file://) → Task 1 transform + escaping test. ✓
+- Path resolution + friendly missing-dir empty state → Task 1 (`get_product_dashboard_dir`, `NotFound`) + Task 3 (`product-empty`). ✓
+- Refresh never blanks page on partial failure → relies on `refresh.sh` behavior; command surfaces non-zero exit as error while prior snapshot stays displayed (Task 2 + Task 3 keep `productHtml`). ✓
+- Rust unit test for transform → Task 1 Steps 1-4. ✓
+- Source tool untouched → no task modifies `~/.claude/tools/...`. ✓
+
+**Placeholder scan:** No TBD/TODO; all steps carry concrete code + exact commands.
+
+**Type consistency:** `get_product_dashboard_dir` (lib.rs) used identically in Tasks 1 & 2. `build_embedded_html(html, sidecar_js)` signature matches its test and caller. Frontend `get_product_dashboard_html` returns `string`; `refresh_product_dashboard` return value unused. State names (`productHtml`, `productError`, `productRefreshing`, `productRefreshedAt`) consistent across Steps 2-4.

--- a/docs/superpowers/specs/2026-07-17-product-dashboard-tab-design.md
+++ b/docs/superpowers/specs/2026-07-17-product-dashboard-tab-design.md
@@ -1,0 +1,107 @@
+# Product Dashboard Tab — Design
+
+**Date:** 2026-07-17
+**Status:** Approved for planning
+
+## Problem
+
+The eventflo Product Dashboard (`~/.claude/tools/product-dashboard/dashboard.html`) is a self-contained
+local page that renders eight panels from live GitHub Projects data (#2 Bugs, #10 Car Park, #11 Tasks,
+#15 v3.1 Release), open PRs per repo, deploys, and personal Google Tasks. A heavy `refresh.sh` regenerates
+`data/dashboard.json` + `data/dashboard.js` (many `gh` CLI calls + Google Tasks + a Go deploys helper);
+cron pre-refreshes it. Today it is opened as a static `file://` page during the morning routine — only as
+fresh as the last refresh, and living outside Synthia.
+
+Goal: bring the dashboard into the Synthia Tauri GUI as a first-class tab that renders the existing page and
+keeps its data live via Synthia-owned refresh.
+
+## Decisions (locked)
+
+- **Render:** embed the existing `dashboard.html` — no React port of the panels. One source of truth with the
+  morning tool; zero re-design.
+- **Placement:** new dedicated `"product"` section in the sidebar (not nested under GitHub).
+- **Refresh owner:** Synthia runs `refresh.sh` (on open, manual button, and a modest interval). The existing
+  cron can coexist harmlessly.
+
+## Architecture
+
+Two Rust IPC commands + one React panel rendering a single `<iframe>`.
+
+### Data / rendering pipeline
+
+The loader in `dashboard.html` always tries to load the `data/dashboard.js` sidecar via a relative
+`<script src>` and falls back to `fetch('data/dashboard.json')`. Both fail inside an embedded frame
+(no base path, no `file://` origin). So the data must be **inlined** into the HTML before it is embedded.
+
+**Rust command `get_product_dashboard_html() -> Result<String, AppError>`**
+
+1. Resolve the dashboard dir (see Path resolution).
+2. Read `dashboard.html`.
+3. Read `data/dashboard.js` — it is already `window.DASHBOARD_DATA = {…};`.
+4. Inject the sidecar contents as an inline `<script>…</script>` immediately before the page's main
+   `<script>` block, so `window.DASHBOARD_DATA` is set before any page code runs.
+5. Rewrite the loader call `loadSidecar()` → `Promise.resolve(window.DASHBOARD_DATA)` so `loadData()` reads
+   the inlined global instead of attempting a file load. (String replace of a single unique substring:
+   `return loadSidecar().then(data =>` → `return Promise.resolve(window.DASHBOARD_DATA).then(data =>`.)
+6. Return the assembled self-contained HTML string.
+
+No CORS, no `file://`, no Tauri asset-protocol scope changes required. The **source tool is not modified.**
+
+**Frontend:** the Product panel renders `<iframe srcDoc={html} className="product-frame" />` filling the
+panel. External Google-Fonts `@import` degrades to system fonts when offline (cosmetic only); project CSP is
+already `null` so fonts load when online.
+
+### Refresh
+
+**Rust command `refresh_product_dashboard() -> Result<RefreshResult, AppError>`**
+
+- Runs `bash refresh.sh` with the dashboard dir as CWD, off the UI thread (async task /
+  `tokio::task::spawn_blocking` consistent with existing command patterns). Returns success/failure plus a
+  completion timestamp.
+- `refresh.sh` already keeps the previous data file when a `gh` fetch fails (rate limit etc.), so a partial
+  or failed refresh never blanks the dashboard.
+
+**Frontend flow (Product panel):**
+
+1. On section open → call `get_product_dashboard_html` immediately and show the last snapshot (fast).
+2. Kick a background `refresh_product_dashboard`; while running, show a subtle "refreshing" indicator.
+3. On completion → re-call `get_product_dashboard_html` and swap the iframe `srcDoc`.
+4. Manual **Refresh** button repeats steps 2–3.
+5. Interval auto-refresh: default **15 minutes**, ticking only while the Product section is active
+   (cleared on unmount / section change). Hard-coded constant.
+
+### Path resolution
+
+Add a helper resolving `~/.claude/tools/product-dashboard`, home-dir based, mirroring the existing
+`paths.rs` conventions (canonicalize-checked). If the directory or `dashboard.html` is missing, the command
+returns a typed `AppError` and the panel shows a friendly "dashboard not found — run the morning tool once"
+message rather than crashing.
+
+### Wiring
+
+- Add `"product"` to the `Section` union in `App.tsx`; add a sidebar nav button (icon + label "Product").
+- Add a `ProductPanel` render branch.
+- Register both commands in the Tauri invoke handler (`lib.rs` + `commands/mod.rs`), in a new
+  `commands/product.rs` module.
+
+## Error handling
+
+- Missing dir / `dashboard.html` → typed `AppError`, friendly empty-state in the panel.
+- `refresh.sh` non-zero exit → surface a non-blocking error toast/line; keep displaying the prior snapshot.
+- `data/dashboard.js` missing (never refreshed) → `get_product_dashboard_html` still returns the page HTML;
+  the page's own no-data handling applies, and the initial background refresh generates the sidecar.
+
+## Testing
+
+- Rust unit test for the HTML assembly transform: given fixture `dashboard.html` + `dashboard.js`, assert the
+  inlined `<script>` is present and the `loadSidecar()` call was rewritten (Rust `cargo test --lib`).
+- Rust: path-resolution helper returns expected path; missing-dir yields `AppError`.
+- Manual: open Product tab, confirm panels render, manual Refresh updates the snapshot, interval fires while
+  active and stops when switching away.
+
+## Out of scope (YAGNI)
+
+- No React reimplementation of the eight panels.
+- No settings UI for the refresh interval (constant, trivially editable).
+- No removal/rewrite of the existing cron.
+- No changes to the eventflo source tool.

--- a/gui/src-tauri/src/commands/mod.rs
+++ b/gui/src-tauri/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod native_term;
 pub mod neuralguard;
 pub mod notes;
 pub mod overlay;
+pub mod product;
 pub mod remote;
 pub mod shortcuts;
 pub mod terminal;

--- a/gui/src-tauri/src/commands/product.rs
+++ b/gui/src-tauri/src/commands/product.rs
@@ -39,6 +39,33 @@ pub async fn get_product_dashboard_html() -> Result<String, AppError> {
     Ok(build_embedded_html(&html, &sidecar))
 }
 
+/// Regenerate the dashboard data by running the tool's `refresh.sh`.
+/// Runs off the UI thread; `refresh.sh` keeps prior data on partial failure.
+#[tauri::command]
+pub async fn refresh_product_dashboard() -> Result<String, AppError> {
+    let dir = get_product_dashboard_dir();
+    if !dir.join("refresh.sh").exists() {
+        return Err(AppError::NotFound("refresh.sh not found".into()));
+    }
+    let output = tauri::async_runtime::spawn_blocking(move || {
+        std::process::Command::new("bash")
+            .arg("refresh.sh")
+            .current_dir(&dir)
+            .output()
+    })
+    .await
+    .map_err(|e| AppError::Process(e.to_string()))?
+    .map_err(|e| AppError::Process(e.to_string()))?;
+
+    if !output.status.success() {
+        return Err(AppError::Process(format!(
+            "refresh.sh failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    Ok("refreshed".to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/gui/src-tauri/src/commands/product.rs
+++ b/gui/src-tauri/src/commands/product.rs
@@ -1,0 +1,66 @@
+//! Product Dashboard Tauri commands.
+//!
+//! Embeds the existing eventflo Product Dashboard (`~/.claude/tools/product-dashboard/`)
+//! into the GUI. `dashboard.html` normally loads its data from a relative
+//! `data/dashboard.js` sidecar (falling back to `fetch`) — neither works inside an
+//! embedded iframe, so we inline the sidecar and rewrite the loader to read the
+//! inlined global. The source tool is never modified.
+
+use crate::error::AppError;
+use crate::get_product_dashboard_dir;
+
+/// Inline the data sidecar into the page and rewrite the loader so an embedded
+/// frame reads `window.DASHBOARD_DATA` directly instead of loading a file.
+pub fn build_embedded_html(html: &str, sidecar_js: &str) -> String {
+    // Neutralize any literal </script> inside JSON string values so the inline
+    // script tag can't be closed early.
+    let safe = sidecar_js.replace("</script>", "<\\/script>");
+    let injected = format!("<head>\n  <script>{safe}</script>");
+    html.replacen("<head>", &injected, 1).replace(
+        "return loadSidecar().then(data =>",
+        "return Promise.resolve(window.DASHBOARD_DATA).then(data =>",
+    )
+}
+
+/// Return the fully self-contained dashboard HTML with data inlined.
+#[tauri::command]
+pub async fn get_product_dashboard_html() -> Result<String, AppError> {
+    let dir = get_product_dashboard_dir();
+    let html_path = dir.join("dashboard.html");
+    if !html_path.exists() {
+        return Err(AppError::NotFound(
+            "Product dashboard not found — run the morning tool once to generate it.".into(),
+        ));
+    }
+    let html = std::fs::read_to_string(&html_path).map_err(|e| AppError::Io(e.to_string()))?;
+    // Sidecar may not exist yet (never refreshed); the page has its own no-data
+    // handling and the first background refresh will generate it.
+    let sidecar = std::fs::read_to_string(dir.join("data/dashboard.js")).unwrap_or_default();
+    Ok(build_embedded_html(&html, &sidecar))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embeds_data_and_rewrites_loader() {
+        let html = "<html><head>\n</head><body><script>\n    function loadSidecar(){}\n    function loadData(){ return loadSidecar().then(data => data); }\n</script></body></html>";
+        let sidecar = "window.DASHBOARD_DATA = {\"x\":1};\n";
+
+        let out = build_embedded_html(html, sidecar);
+
+        assert!(out.contains("window.DASHBOARD_DATA = {\"x\":1};"), "sidecar inlined");
+        assert!(out.contains("Promise.resolve(window.DASHBOARD_DATA).then(data =>"), "loader rewritten");
+        assert!(!out.contains("return loadSidecar().then(data =>"), "old loader call gone");
+    }
+
+    #[test]
+    fn escapes_nested_script_close() {
+        let html = "<head>\n</head>";
+        let sidecar = "window.DASHBOARD_DATA = {\"t\":\"a</script>b\"};";
+        let out = build_embedded_html(html, sidecar);
+        assert!(!out.contains("a</script>b"), "nested close escaped");
+        assert!(out.contains("a<\\/script>b"), "escaped form present");
+    }
+}

--- a/gui/src-tauri/src/commands/product.rs
+++ b/gui/src-tauri/src/commands/product.rs
@@ -11,12 +11,20 @@ use crate::get_product_dashboard_dir;
 
 /// Inline the data sidecar into the page and rewrite the loader so an embedded
 /// frame reads `window.DASHBOARD_DATA` directly instead of loading a file.
+///
+/// NOTE: the loader rewrite depends on the source tool's `dashboard.html` still
+/// containing the exact `return loadSidecar().then(data =>` call. Both files are
+/// co-maintained; if the tool's loader is reworded, update this string too.
 pub fn build_embedded_html(html: &str, sidecar_js: &str) -> String {
-    // Neutralize any literal </script> inside JSON string values so the inline
-    // script tag can't be closed early.
-    let safe = sidecar_js.replace("</script>", "<\\/script>");
-    let injected = format!("<head>\n  <script>{safe}</script>");
-    html.replacen("<head>", &injected, 1).replace(
+    // Neutralize every `<` in the data so no `</script>`, `<script>` or `<!--`
+    // sequence — in any case, with any spacing — can terminate the inline
+    // script early. `<` only ever appears inside JSON string values, and
+    // `<` parses back to `<` at runtime, so this is lossless.
+    let safe = sidecar_js.replace('<', "\\u003C");
+    // Inject before `</head>` (tolerant of attributes on the <head> tag) so the
+    // data global is set before any page code runs.
+    let injected = format!("  <script>{safe}</script>\n</head>");
+    html.replacen("</head>", &injected, 1).replace(
         "return loadSidecar().then(data =>",
         "return Promise.resolve(window.DASHBOARD_DATA).then(data =>",
     )
@@ -33,9 +41,16 @@ pub async fn get_product_dashboard_html() -> Result<String, AppError> {
         ));
     }
     let html = std::fs::read_to_string(&html_path).map_err(|e| AppError::Io(e.to_string()))?;
-    // Sidecar may not exist yet (never refreshed); the page has its own no-data
-    // handling and the first background refresh will generate it.
+    // Sidecar may not exist yet (never refreshed). Without it the rewritten
+    // loader would resolve `undefined` and fall through to a relative fetch that
+    // cannot resolve inside a srcDoc iframe — so surface a friendly "not ready"
+    // state instead. The caller kicks a refresh that generates the sidecar.
     let sidecar = std::fs::read_to_string(dir.join("data/dashboard.js")).unwrap_or_default();
+    if sidecar.trim().is_empty() {
+        return Err(AppError::NotFound(
+            "Dashboard data not generated yet — refreshing…".into(),
+        ));
+    }
     Ok(build_embedded_html(&html, &sidecar))
 }
 
@@ -72,22 +87,32 @@ mod tests {
 
     #[test]
     fn embeds_data_and_rewrites_loader() {
-        let html = "<html><head>\n</head><body><script>\n    function loadSidecar(){}\n    function loadData(){ return loadSidecar().then(data => data); }\n</script></body></html>";
+        let html = "<html><head lang=\"en\">\n</head><body><script>\n    function loadSidecar(){}\n    function loadData(){ return loadSidecar().then(data => data); }\n</script></body></html>";
         let sidecar = "window.DASHBOARD_DATA = {\"x\":1};\n";
 
         let out = build_embedded_html(html, sidecar);
 
+        // Injected before </head>, tolerant of attributes on the <head> tag.
         assert!(out.contains("window.DASHBOARD_DATA = {\"x\":1};"), "sidecar inlined");
+        assert!(
+            out.find("window.DASHBOARD_DATA").unwrap() < out.find("</head>").unwrap(),
+            "data injected before </head>"
+        );
         assert!(out.contains("Promise.resolve(window.DASHBOARD_DATA).then(data =>"), "loader rewritten");
         assert!(!out.contains("return loadSidecar().then(data =>"), "old loader call gone");
     }
 
     #[test]
-    fn escapes_nested_script_close() {
+    fn neutralizes_all_script_close_variants() {
+        // Case + whitespace variants and opening tags must all be escaped.
         let html = "<head>\n</head>";
-        let sidecar = "window.DASHBOARD_DATA = {\"t\":\"a</script>b\"};";
+        let sidecar =
+            "window.DASHBOARD_DATA = {\"a\":\"x</script>y\",\"b\":\"p</SCRIPT >q\",\"c\":\"<!--z\"};";
         let out = build_embedded_html(html, sidecar);
-        assert!(!out.contains("a</script>b"), "nested close escaped");
-        assert!(out.contains("a<\\/script>b"), "escaped form present");
+        // No raw `<` from the data survives (would let the browser act on it).
+        assert!(!out.contains("x</script>y"), "lowercase closer escaped");
+        assert!(!out.contains("p</SCRIPT >q"), "uppercase/spaced closer escaped");
+        assert!(!out.contains("<!--z"), "comment opener escaped");
+        assert!(out.contains("x\\u003C/script>y"), "escaped form present");
     }
 }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -544,6 +544,7 @@ pub fn run() {
             commands::usage::get_usage_stats,
             commands::weather::get_weather,
             commands::product::get_product_dashboard_html,
+            commands::product::refresh_product_dashboard,
             commands::youtube_feed::get_youtube_videos,
             commands::youtube_feed::list_youtube_channels,
             commands::youtube_feed::add_youtube_channel,

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -125,6 +125,10 @@ pub(crate) fn get_memory_dir() -> PathBuf {
     get_claude_dir().join("memory")
 }
 
+pub(crate) fn get_product_dashboard_dir() -> PathBuf {
+    get_claude_dir().join("tools/product-dashboard")
+}
+
 pub(crate) fn get_agents_dir() -> PathBuf {
     get_claude_dir().join("agents")
 }
@@ -539,6 +543,7 @@ pub fn run() {
             commands::notes::delete_note,
             commands::usage::get_usage_stats,
             commands::weather::get_weather,
+            commands::product::get_product_dashboard_html,
             commands::youtube_feed::get_youtube_videos,
             commands::youtube_feed::list_youtube_channels,
             commands::youtube_feed::add_youtube_channel,

--- a/gui/src/App.css
+++ b/gui/src/App.css
@@ -5596,3 +5596,34 @@
   font-style: italic;
   padding: 8px 10px;
 }
+
+.product-section {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+.product-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+.product-title { font-weight: 600; }
+.product-status { color: #9a9aa8; font-size: 12px; margin-left: auto; }
+.product-frame {
+  flex: 1;
+  width: 100%;
+  border: none;
+  background: #08080c;
+}
+.product-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #9a9aa8;
+  padding: 40px;
+  text-align: center;
+}

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -400,7 +400,7 @@ interface GitHubIssuesResponse {
   error: string | null;
 }
 
-type Section = "worktrees" | "terminal" | "shortcuts" | "knowledge" | "agents" | "security" | "voice" | "memory" | "config" | "github";
+type Section = "worktrees" | "terminal" | "shortcuts" | "knowledge" | "agents" | "security" | "voice" | "memory" | "config" | "github" | "product";
 
 interface KnowledgeMeta {
   pinned: string[];
@@ -543,6 +543,12 @@ function App() {
   const [githubConfigOpen, setGithubConfigOpen] = useState(false);
   const [newGithubRepo, setNewGithubRepo] = useState("");
 
+  // Product dashboard state
+  const [productHtml, setProductHtml] = useState<string>("");
+  const [productError, setProductError] = useState<string | null>(null);
+  const [productRefreshing, setProductRefreshing] = useState(false);
+  const [productRefreshedAt, setProductRefreshedAt] = useState<string>("");
+
   // Active agents monitor state
   const [activeAgents, setActiveAgents] = useState<AgentInfo[]>([]);
   const [expandedAgentPid, setExpandedAgentPid] = useState<number | null>(null);
@@ -664,6 +670,15 @@ function App() {
       loadGithubIssues(true);
     }
   }, [githubConfigOpen]);
+
+  useEffect(() => {
+    if (currentSection !== "product") return;
+    loadProductHtml();
+    refreshProductDashboard();
+    const id = setInterval(refreshProductDashboard, 15 * 60 * 1000);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentSection]);
 
   // Terminal tab list — poll every 500ms while on terminal section so the
   // sidebar sub-items stay in sync with backend state (new tabs, closes,
@@ -1099,6 +1114,29 @@ function App() {
       setGithubConfig({ repos, refresh_interval_seconds: refreshInterval });
     } catch (e) {
       setGithubError(String(e));
+    }
+  }
+
+  async function loadProductHtml() {
+    try {
+      const html = await invoke<string>("get_product_dashboard_html");
+      setProductHtml(html);
+      setProductError(null);
+    } catch (e) {
+      setProductError(typeof e === "string" ? e : JSON.stringify(e));
+    }
+  }
+
+  async function refreshProductDashboard() {
+    setProductRefreshing(true);
+    try {
+      await invoke("refresh_product_dashboard");
+      await loadProductHtml();
+      setProductRefreshedAt(new Date().toLocaleTimeString("en-AU"));
+    } catch (e) {
+      setProductError(typeof e === "string" ? e : JSON.stringify(e));
+    } finally {
+      setProductRefreshing(false);
     }
   }
 
@@ -2567,6 +2605,13 @@ function App() {
             {(() => { const c = githubIssues.filter(i => i.state === "OPEN").length; return c > 0 ? <span className="nav-badge">{c}</span> : null; })()}
           </button>
           <button
+            className={`nav-item ${currentSection === "product" ? "active" : ""}`}
+            onClick={() => setCurrentSection("product")}
+          >
+            <span className="nav-item-icon">&#128202;</span>
+            Product
+          </button>
+          <button
             className={`nav-item ${currentSection === "voice" ? "active" : ""}`}
             onClick={() => { setCurrentSection("voice"); setVoiceView("main"); }}
           >
@@ -3073,6 +3118,39 @@ function App() {
               </button>
             </div>
           </div>
+        )}
+      </div>
+    );
+  }
+
+  function renderProductSection() {
+    return (
+      <div className="product-section">
+        <div className="product-toolbar">
+          <span className="product-title">Product Dashboard</span>
+          <span className="product-status">
+            {productRefreshing
+              ? "Refreshing…"
+              : productRefreshedAt
+              ? `Updated ${productRefreshedAt}`
+              : ""}
+          </span>
+          <button
+            className="task-panel-btn primary"
+            onClick={refreshProductDashboard}
+            disabled={productRefreshing}
+          >
+            Refresh
+          </button>
+        </div>
+        {productError ? (
+          <div className="product-empty">{productError}</div>
+        ) : (
+          <iframe
+            className="product-frame"
+            title="Product Dashboard"
+            srcDoc={productHtml}
+          />
         )}
       </div>
     );
@@ -4825,6 +4903,7 @@ function App() {
           )}
           {currentSection === "shortcuts" && <ShortcutsPanel />}
           {currentSection === "github" && renderGithubSection()}
+          {currentSection === "product" && renderProductSection()}
           {currentSection === "knowledge" && renderKnowledgeSection()}
           {currentSection === "voice" && renderVoiceSection()}
           {currentSection === "memory" && renderMemorySection()}

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import Markdown from "react-markdown";
@@ -548,6 +548,10 @@ function App() {
   const [productError, setProductError] = useState<string | null>(null);
   const [productRefreshing, setProductRefreshing] = useState(false);
   const [productRefreshedAt, setProductRefreshedAt] = useState<string>("");
+  const [productRefreshFailed, setProductRefreshFailed] = useState(false);
+  // Reentrancy guard so the interval can't start a second refresh.sh while one
+  // is still running (concurrent writes to the same data files corrupt it).
+  const productRefreshingRef = useRef(false);
 
   // Active agents monitor state
   const [activeAgents, setActiveAgents] = useState<AgentInfo[]>([]);
@@ -674,7 +678,10 @@ function App() {
   useEffect(() => {
     if (currentSection !== "product") return;
     loadProductHtml();
-    refreshProductDashboard();
+    // refresh.sh is heavy (many gh calls) — only run it on the first visit this
+    // session; the interval keeps it live afterwards. Re-entering the tab just
+    // re-reads the current snapshot.
+    if (!productRefreshedAt) refreshProductDashboard();
     const id = setInterval(refreshProductDashboard, 15 * 60 * 1000);
     return () => clearInterval(id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1117,25 +1124,43 @@ function App() {
     }
   }
 
+  function productErrText(e: unknown): string {
+    if (typeof e === "string") return e;
+    if (e && typeof e === "object") {
+      // AppError serializes as { Variant: "message" } — surface the message.
+      const v = Object.values(e as Record<string, unknown>)[0];
+      if (typeof v === "string") return v;
+    }
+    return JSON.stringify(e);
+  }
+
   async function loadProductHtml() {
     try {
       const html = await invoke<string>("get_product_dashboard_html");
       setProductHtml(html);
       setProductError(null);
     } catch (e) {
-      setProductError(typeof e === "string" ? e : JSON.stringify(e));
+      // Only becomes visible when there's no prior snapshot (render gates the
+      // empty-state on productHtml); a transient failure never blanks a good page.
+      setProductError(productErrText(e));
     }
   }
 
   async function refreshProductDashboard() {
+    if (productRefreshingRef.current) return; // never run two refresh.sh at once
+    productRefreshingRef.current = true;
     setProductRefreshing(true);
     try {
       await invoke("refresh_product_dashboard");
       await loadProductHtml();
       setProductRefreshedAt(new Date().toLocaleTimeString("en-AU"));
+      setProductRefreshFailed(false);
     } catch (e) {
-      setProductError(typeof e === "string" ? e : JSON.stringify(e));
+      // Keep the last good dashboard on screen; flag the failure in the toolbar.
+      setProductRefreshFailed(true);
+      if (!productHtml) setProductError(productErrText(e));
     } finally {
+      productRefreshingRef.current = false;
       setProductRefreshing(false);
     }
   }
@@ -3131,6 +3156,8 @@ function App() {
           <span className="product-status">
             {productRefreshing
               ? "Refreshing…"
+              : productRefreshFailed
+              ? "Refresh failed — showing last snapshot"
               : productRefreshedAt
               ? `Updated ${productRefreshedAt}`
               : ""}
@@ -3143,14 +3170,14 @@ function App() {
             Refresh
           </button>
         </div>
-        {productError ? (
-          <div className="product-empty">{productError}</div>
-        ) : (
+        {productHtml ? (
           <iframe
             className="product-frame"
             title="Product Dashboard"
             srcDoc={productHtml}
           />
+        ) : (
+          <div className="product-empty">{productError ?? "Loading…"}</div>
         )}
       </div>
     );


### PR DESCRIPTION
## Summary

Adds a **Product** tab to the Synthia GUI that embeds the existing eventflo Product Dashboard (`~/.claude/tools/product-dashboard/dashboard.html`) and keeps it live — no more static `file://` open during the morning routine. The source tool is never modified.

## How it works

- **`get_product_dashboard_html`** (Rust): reads `dashboard.html`, inlines the `data/dashboard.js` sidecar as an inline `<script>`, and rewrites the loader so an embedded `srcDoc` iframe reads `window.DASHBOARD_DATA` directly — no CORS, no `file://`, no asset-protocol scope. Every `<` in the data is escaped so titles can't break the inline script. Missing data returns a friendly "not generated yet" state.
- **`refresh_product_dashboard`** (Rust): runs `refresh.sh` off the UI thread; `refresh.sh` keeps prior data on partial failure.
- **Product tab** (React): full-height panel with the iframe, a manual Refresh button, and a status line. Refreshes on first entry + every 15 min while active; a reentrancy guard prevents overlapping `refresh.sh` runs; a transient refresh failure keeps the last-good dashboard on screen instead of blanking it.

## Changes

- `gui/src-tauri/src/commands/product.rs` (new) — both commands + unit tests
- `gui/src-tauri/src/lib.rs` — `get_product_dashboard_dir()` helper + command registration
- `gui/src-tauri/src/commands/mod.rs` — module registration
- `gui/src/App.tsx` — Section, state, nav button, `renderProductSection`, load/refresh, effect
- `gui/src/App.css` — panel styles
- `docs/superpowers/{specs,plans}/2026-07-17-product-dashboard-tab*` — design + plan

## Test plan

- [ ] Open the Product tab → panels render in the iframe
- [ ] Status shows "Refreshing…" then "Updated <time>"; manual Refresh works
- [ ] Toggle away and back → no duplicate/concurrent refresh.sh
- [ ] Rename `dashboard.html` → friendly empty-state, no crash

Built with the superpowers brainstorm → spec → plan flow; implementation dispatched to Kimi K2.7, then a high-effort `/code-review` pass — 6 findings fixed before this description.

🤖 Dispatched to Kimi K2.7 via Kimi CLI
